### PR TITLE
Add separate parsing of fatal logs

### DIFF
--- a/examples/h265_transcode.rs
+++ b/examples/h265_transcode.rs
@@ -1,6 +1,9 @@
 use std::{io::Write, path::Path, thread};
 
-use ffmpeg_sidecar::{command::FfmpegCommand, event::FfmpegEvent};
+use ffmpeg_sidecar::{
+  command::FfmpegCommand,
+  event::{FfmpegEvent, LogLevel},
+};
 
 /// 1. Read an H265 source video from file
 /// 2. Decode video
@@ -59,7 +62,7 @@ fn main() {
 
   // On the main thread, run the output instance to completion
   output.iter().unwrap().for_each(|e| match e {
-    FfmpegEvent::LogError(e) => println!("Error: {}", e),
+    FfmpegEvent::Log(LogLevel::Error, e) => println!("Error: {}", e),
     FfmpegEvent::Progress(p) => println!("Progress: {} / 00:00:15", p.time),
     _ => {}
   });
@@ -76,7 +79,7 @@ fn create_h265_source(path_str: &str) {
     .iter()
     .unwrap()
     .for_each(|e| match e {
-      FfmpegEvent::LogError(e) => println!("Error: {}", e),
+      FfmpegEvent::Log(LogLevel::Error, e) => println!("Error: {}", e),
       FfmpegEvent::Progress(p) => println!("Progress: {} / 00:00:15", p.time),
       _ => {}
     });

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,6 +9,7 @@ pub enum FfmpegEvent {
   LogInfo(String),
   LogWarning(String),
   LogError(String),
+  LogFatal(String),
   LogUnknown(String),
   LogEOF,
   /// An error that didn't originate from the ffmpeg logs

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,11 +6,7 @@ pub enum FfmpegEvent {
   ParsedOutput(FfmpegOutput),
   ParsedInputStream(AVStream),
   ParsedOutputStream(AVStream),
-  LogInfo(String),
-  LogWarning(String),
-  LogError(String),
-  LogFatal(String),
-  LogUnknown(String),
+  Log(LogLevel, String),
   LogEOF,
   /// An error that didn't originate from the ffmpeg logs
   Error(String),
@@ -22,6 +18,15 @@ pub enum FfmpegEvent {
   /// another FFmpeg instance.
   OutputChunk(Vec<u8>),
   Done,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogLevel {
+  Info,
+  Warning,
+  Error,
+  Fatal,
+  Unknown,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -115,6 +115,7 @@ impl FfmpegIterator {
       FfmpegEvent::LogInfo(x) => Some(x),
       FfmpegEvent::LogWarning(x) => Some(x),
       FfmpegEvent::LogError(x) => Some(x),
+      FfmpegEvent::LogFatal(x) => Some(x),
       FfmpegEvent::LogUnknown(x) => Some(x),
       FfmpegEvent::LogEOF => None,
       FfmpegEvent::Error(_) => None,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
   child::FfmpegChild,
   error::{Error, Result},
-  event::{AVStream, FfmpegEvent, FfmpegOutput, FfmpegProgress, OutputVideoFrame},
+  event::{AVStream, FfmpegEvent, FfmpegOutput, FfmpegProgress, LogLevel, OutputVideoFrame},
   log_parser::FfmpegLogParser,
   pix_fmt::get_bytes_per_frame,
 };
@@ -73,7 +73,7 @@ impl FfmpegIterator {
   /// Returns an iterator over error messages (`FfmpegEvent::Error` and `FfmpegEvent::LogError`).
   pub fn filter_errors(self) -> impl Iterator<Item = String> {
     self.filter_map(|event| match event {
-      FfmpegEvent::Error(e) | FfmpegEvent::LogError(e) => Some(e),
+      FfmpegEvent::Error(e) | FfmpegEvent::Log(LogLevel::Error, e) => Some(e),
       _ => None,
     })
   }
@@ -112,11 +112,7 @@ impl FfmpegIterator {
       FfmpegEvent::ParsedOutput(x) => Some(x.raw_log_message),
       FfmpegEvent::ParsedInputStream(x) => Some(x.raw_log_message),
       FfmpegEvent::ParsedOutputStream(x) => Some(x.raw_log_message),
-      FfmpegEvent::LogInfo(x) => Some(x),
-      FfmpegEvent::LogWarning(x) => Some(x),
-      FfmpegEvent::LogError(x) => Some(x),
-      FfmpegEvent::LogFatal(x) => Some(x),
-      FfmpegEvent::LogUnknown(x) => Some(x),
+      FfmpegEvent::Log(_, x) => Some(x),
       FfmpegEvent::LogEOF => None,
       FfmpegEvent::Error(_) => None,
       FfmpegEvent::Progress(x) => Some(x.raw_log_message),

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -79,13 +79,13 @@ impl<R: Read> FfmpegLogParser<R> {
         } else if let Some(progress) = try_parse_progress(line) {
           self.cur_section = LogSection::Other;
           Ok(FfmpegEvent::Progress(progress))
-        } else if line.starts_with("[info]") {
+        } else if line.contains("[info]") {
           Ok(FfmpegEvent::LogInfo(line.to_string()))
-        } else if line.starts_with("[warning]") {
+        } else if line.contains("[warning]") {
           Ok(FfmpegEvent::LogWarning(line.to_string()))
-        } else if line.starts_with("[error]") {
+        } else if line.contains("[error]") {
           Ok(FfmpegEvent::LogError(line.to_string()))
-        } else if line.starts_with("[fatal]") {
+        } else if line.contains("[fatal]") {
           Ok(FfmpegEvent::LogFatal(line.to_string()))
         } else {
           Ok(FfmpegEvent::LogUnknown(line.to_string()))

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -8,6 +8,7 @@ use crate::{
   error::{Error, Result},
   event::{
     AVStream, FfmpegConfiguration, FfmpegEvent, FfmpegOutput, FfmpegProgress, FfmpegVersion,
+    LogLevel,
   },
   read_until_any::read_until_any,
 };
@@ -80,15 +81,15 @@ impl<R: Read> FfmpegLogParser<R> {
           self.cur_section = LogSection::Other;
           Ok(FfmpegEvent::Progress(progress))
         } else if line.contains("[info]") {
-          Ok(FfmpegEvent::LogInfo(line.to_string()))
+          Ok(FfmpegEvent::Log(LogLevel::Info, line.to_string()))
         } else if line.contains("[warning]") {
-          Ok(FfmpegEvent::LogWarning(line.to_string()))
+          Ok(FfmpegEvent::Log(LogLevel::Warning, line.to_string()))
         } else if line.contains("[error]") {
-          Ok(FfmpegEvent::LogError(line.to_string()))
+          Ok(FfmpegEvent::Log(LogLevel::Error, line.to_string()))
         } else if line.contains("[fatal]") {
-          Ok(FfmpegEvent::LogFatal(line.to_string()))
+          Ok(FfmpegEvent::Log(LogLevel::Fatal, line.to_string()))
         } else {
-          Ok(FfmpegEvent::LogUnknown(line.to_string()))
+          Ok(FfmpegEvent::Log(LogLevel::Unknown, line.to_string()))
         }
       }
       Err(e) => Err(Error::from_std(e)),

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -83,8 +83,10 @@ impl<R: Read> FfmpegLogParser<R> {
           Ok(FfmpegEvent::LogInfo(line.to_string()))
         } else if line.starts_with("[warning]") {
           Ok(FfmpegEvent::LogWarning(line.to_string()))
-        } else if line.starts_with("[error]") || line.starts_with("[fatal]") {
+        } else if line.starts_with("[error]") {
           Ok(FfmpegEvent::LogError(line.to_string()))
+        } else if line.starts_with("[fatal]") {
+          Ok(FfmpegEvent::LogFatal(line.to_string()))
         } else {
           Ok(FfmpegEvent::LogUnknown(line.to_string()))
         }


### PR DESCRIPTION
This PR adds a separate parsing of fatal error logs so that they can be handled separately. I initially did this by adding a `FfmpegEvent::LogFatal` but in the last commit I changed this to make it a single `FfmpegEvent::Log` with a `LogLevel` field. I don't have a strong opinion in either direction so I'll leave the decision up to you.

I also changed the log parsing logic  to check if a log line contains the log level in square braces (instead of starting with it) because I encountered a few logs like this that would otherwise be parsed incorrectly:
```
[swscaler @ 000001ceadc00b80] [swscaler @ 000001ceadd3b7c0] [warning] deprecated pixel format 
used, make sure you did set range correctly
```

I didn't add tests because there currently aren't any for the `parse_next_event` function and I didn't know how you want that set up.