### PR TITLE
Add option to not create console window when spawning ffmpeg on Windows

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -567,6 +567,15 @@ impl FfmpegCommand {
     self
   }
 
+  /// Disable creating a new console window for the spawned process on Windows.
+  /// Has no effect on other platforms. This can be usefull when spawning ffmpeg
+  /// from a GUI program.
+  pub fn create_no_window(&mut self) -> &mut Self {
+    #[cfg(target_os = "windows")]
+    std::os::windows::process::CommandExt::creation_flags(self.as_inner_mut(), 0x08000000);
+    self
+  }
+
   //// Constructors
   pub fn new() -> Self {
     Self::new_with_path(ffmpeg_path())


### PR DESCRIPTION
This adds a convenience function to disable creating a new console window for every spawned ffmpeg process when running on Windows. This is especially useful when you use this library for a GUI program where you don't want to open a bunch of empty console widows.