### PR TITLE
Fix the print_command() method to print an easily copyable command

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -563,7 +563,16 @@ impl FfmpegCommand {
   /// `&mut self` so that it chains seamlessly with other methods in the
   /// interface.
   pub fn print_command(&mut self) -> &mut Self {
-    println!("Command: {:?}", self.inner);
+    let program = self.inner.get_program().to_str();
+    let args = self
+      .inner
+      .get_args()
+      .map(|s| s.to_str())
+      .collect::<Option<Vec<_>>>();
+    if let (Some(program), Some(args)) = (program, args) {
+      println!("Command: {} {}", program, args.join(" "));
+    }
+
     self
   }
 


### PR DESCRIPTION
I noticed during debugging that the current implementation doesn't produce an output that can be copy-pasted and run so here's a quick fix for that.