### PR TITLE
Improve Iterator metadata collection

### DIFF
--- a/examples/h265_transcode.rs
+++ b/examples/h265_transcode.rs
@@ -29,7 +29,7 @@ fn main() {
 
   // Frames can be transformed by Iterator `.map()`.
   // This example is a no-op, with frames passed through unaltered.
-  let transformed_frames = input.iter().unwrap().filter_frames().map(|f| f);
+  let transformed_frames = input.iter().unwrap().filter_frames();
 
   // You could easily add some "middleware" processing here:
   // - overlay or composite another RGB image (or even another Ffmpeg Iterator)

--- a/src/child.rs
+++ b/src/child.rs
@@ -14,7 +14,7 @@ pub struct FfmpegChild {
 }
 
 impl FfmpegChild {
-  /// Creates an iterator over events emitted by ffmpeg. Functions similarly to
+  /// Creates an iterator over events emitted by FFmpeg. Functions similarly to
   /// `Lines` from [`std::io::BufReader`], but providing a variety of parsed
   /// events:
   /// - Log messages

--- a/src/download.rs
+++ b/src/download.rs
@@ -92,7 +92,7 @@ pub fn parse_macos_version(version: &str) -> Option<String> {
     .split("\"version\":")
     .nth(1)?
     .trim()
-    .split("\"")
+    .split('\"')
     .nth(1)
     .map(|s| s.to_string())
 }
@@ -111,7 +111,6 @@ pub fn parse_linux_version(version: &str) -> Option<String> {
   version
     .split("version:")
     .nth(1)?
-    .trim_start()
     .split_whitespace()
     .next()
     .map(|s| s.to_string())
@@ -208,15 +207,15 @@ pub fn unpack_ffmpeg(from_archive: &PathBuf, binary_folder: &PathBuf) -> Result<
 
   let (ffmpeg, ffplay, ffprobe) = if cfg!(target_os = "windows") {
     (
-      (&inner_folder).path().join("bin/ffmpeg.exe"),
-      (&inner_folder).path().join("bin/ffplay.exe"),
-      (&inner_folder).path().join("bin/ffprobe.exe"),
+      inner_folder.path().join("bin/ffmpeg.exe"),
+      inner_folder.path().join("bin/ffplay.exe"),
+      inner_folder.path().join("bin/ffprobe.exe"),
     )
   } else if cfg!(any(target_os = "linux", target_os = "macos")) {
     (
-      (&inner_folder).path().join("./ffmpeg"),
-      (&inner_folder).path().join("./ffplay"), // <- this typically only exists in Windows builds
-      (&inner_folder).path().join("./ffprobe"),
+      inner_folder.path().join("./ffmpeg"),
+      inner_folder.path().join("./ffplay"), // <- this typically only exists in Windows builds
+      inner_folder.path().join("./ffprobe"),
     )
   } else {
     return Err(Error::msg("Unsupported platform"));

--- a/src/event.rs
+++ b/src/event.rs
@@ -45,6 +45,8 @@ impl FfmpegOutput {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AVStream {
+  /// Typically `video` or `audio`, but might be something else like `data` or `subtitle`.
+  pub stream_type: String,
   /// Corresponds to stream `-f` parameter, e.g. `rawvideo`, `h264`, or `mpegts`
   pub format: String,
   /// Corresponds to stream `-pix_fmt` parameter, e.g. `rgb24`

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -188,16 +188,16 @@ pub fn spawn_stdout_thread(
         .unwrap_or(false)
     });
 
-    // Limit to exactly one non-rawvideo stream,
-    // or unlimited rawvideo streams
-    if stdout_output_streams
+    // Error on mixing rawvideo and non-rawvideo streams
+    // TODO: Maybe just revert to chunk mode if this happens?
+    let any_rawvideo = stdout_output_streams
       .clone()
-      .any(|s| s.format != "rawvideo")
-    {
-      assert!(
-        stdout_output_streams.clone().count() == 1,
-        "Only one non-rawvideo output stream can be sent to stdout",
-      );
+      .any(|s| s.format == "rawvideo");
+    let any_non_rawvideo = stdout_output_streams
+      .clone()
+      .any(|s| s.format != "rawvideo");
+    if any_rawvideo && any_non_rawvideo {
+      panic!("Cannot mix rawvideo and non-rawvideo streams");
     }
 
     // Prepare buffers

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -21,6 +21,7 @@ pub struct FfmpegIterator {
   metadata: FfmpegMetadata,
 }
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct FfmpegMetadata {
   expected_output_streams: usize,
   output_streams: Vec<AVStream>,
@@ -93,6 +94,15 @@ impl FfmpegIterator {
     }
 
     Ok(())
+  }
+
+  /// Advance the iterator until all metadata has been collected, returning it.
+  pub fn collect_metadata(&mut self) -> FfmpegMetadata {
+    while !self.metadata.completed {
+      self.next();
+    }
+
+    self.metadata.clone()
   }
 
   //// Iterator filters

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -292,7 +292,6 @@ pub fn try_parse_stream(mut string: &str) -> Option<AVStream> {
   let fps = string
     .split("fps,")
     .next()?
-    .trim()
     .split_whitespace()
     .last()?
     .parse()

--- a/src/read_until_any.rs
+++ b/src/read_until_any.rs
@@ -18,7 +18,7 @@ pub fn read_until_any<R: BufRead + ?Sized>(
       // NB: `memchr` crate would be faster, but it's unstable and not worth the dependency.
       let first_delim_index = available
         .iter()
-        .position(|b| delims.iter().find(|d| **d == *b).is_some());
+        .position(|b| delims.iter().any(|d| *d == *b));
 
       match first_delim_index {
         Some(i) => {

--- a/src/test.rs
+++ b/src/test.rs
@@ -166,6 +166,30 @@ fn test_chunks() {
 }
 
 #[test]
+fn test_chunks_with_audio() {
+  let mut chunks = 0;
+  let mut frames = 0;
+
+  FfmpegCommand::new()
+    .testsrc()
+    .args("-f lavfi -i sine=frequency=1000 -shortest".split(' '))
+    .codec_video("libx264")
+    .format("mpegts")
+    .pipe_stdout()
+    .spawn()
+    .unwrap()
+    .iter()
+    .unwrap()
+    .for_each(|e| match e {
+      FfmpegEvent::OutputChunk(_) => chunks += 1,
+      FfmpegEvent::OutputFrame(_) => frames += 1,
+      _ => {}
+    });
+
+  assert!(chunks > 0);
+}
+
+#[test]
 fn test_kill_before_iter() {
   let mut child = FfmpegCommand::new().testsrc().rawvideo().spawn().unwrap();
   child.kill().unwrap();


### PR DESCRIPTION
Closes #10 

- Rewrite metadata collection to avoid an inner loop inside the constructor
  - On certain errors execution could block inside this inner loop, never yielding items to the Iterator
- Collect metadata into a single struct
- Add `collect_metadata` method to advance iterator past metadata section and return the finalized metadata
- Recognize audio streams and other stream types, though no parsing of their contents yet