### PR TITLE
Duration metadata

### DIFF
--- a/examples/trigger.rs
+++ b/examples/trigger.rs
@@ -51,13 +51,6 @@ impl<Root> Trigger<Root, String> {
   }
 }
 
-struct ImageTrigger;
-impl ImageTrigger {
-  fn new() -> Trigger<Image, Image> {
-    Trigger::new()
-  }
-}
-
 fn image_trigger() -> Trigger<Image, Image> {
   Trigger::new()
 }
@@ -80,5 +73,5 @@ fn main() {
   assert!(my_string == "[(asdf)]!");
 
   let _trigger = Trigger::<String, String>::new();
-  ImageTrigger::new().run(Image);
+  image_trigger().run(Image);
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -127,7 +127,7 @@ pub fn curl(url: &str) -> Result<String> {
   let stdout = child
     .stdout
     .take()
-    .ok_or(Error::msg("Failed to get stdout"))?;
+    .ok_or_else(|| Error::msg("Failed to get stdout"))?;
 
   let mut string = String::new();
   std::io::BufReader::new(stdout).read_to_string(&mut string)?;
@@ -161,10 +161,10 @@ pub fn check_latest_version() -> Result<String> {
 
 /// Invoke `curl` to download an archive (ZIP on windows, TAR on linux and mac)
 /// from the latest published release online.
-pub fn download_ffmpeg_package(url: &str, download_dir: &PathBuf) -> Result<PathBuf> {
+pub fn download_ffmpeg_package(url: &str, download_dir: &Path) -> Result<PathBuf> {
   let filename = Path::new(url)
     .file_name()
-    .ok_or(Error::msg("Failed to get filename"))?;
+    .ok_or_else(|| Error::msg("Failed to get filename"))?;
 
   let archive_path = download_dir.join(filename);
 
@@ -181,7 +181,7 @@ pub fn download_ffmpeg_package(url: &str, download_dir: &PathBuf) -> Result<Path
 
 /// After downloading, unpacks the archive to a folder, moves the binaries to
 /// their final location, and deletes the archive and temporary folder.
-pub fn unpack_ffmpeg(from_archive: &PathBuf, binary_folder: &PathBuf) -> Result<()> {
+pub fn unpack_ffmpeg(from_archive: &PathBuf, binary_folder: &Path) -> Result<()> {
   let temp_dirname = UNPACK_DIRNAME;
   let temp_folder = binary_folder.join(temp_dirname);
   create_dir_all(&temp_folder)?;

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,9 +3,11 @@ pub enum FfmpegEvent {
   ParsedVersion(FfmpegVersion),
   ParsedConfiguration(FfmpegConfiguration),
   ParsedStreamMapping(String),
+  ParsedInput(FfmpegInput),
   ParsedOutput(FfmpegOutput),
   ParsedInputStream(AVStream),
   ParsedOutputStream(AVStream),
+  ParsedDuration(FfmpegDuration),
   Log(LogLevel, String),
   LogEOF,
   /// An error that didn't originate from the ffmpeg logs
@@ -27,6 +29,20 @@ pub enum LogLevel {
   Error,
   Fatal,
   Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FfmpegInput {
+  pub index: u32,
+  pub duration: Option<f64>,
+  pub raw_log_message: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FfmpegDuration {
+  pub input_index: u32,
+  pub duration: f64,
+  pub raw_log_message: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -137,3 +153,5 @@ impl std::fmt::Debug for OutputVideoFrame {
       .finish()
   }
 }
+
+// TODO fix the output for OutputChunk also

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -35,6 +35,17 @@ pub struct FfmpegMetadata {
   completed: bool,
 }
 
+impl FfmpegMetadata {
+  /// A shortcut to obtain the expected duration (in seconds) of an FFmpeg job.
+  ///
+  /// Usually this is the duration of the first input stream. Theoretically
+  /// different streams could have different (or conflicting) durations, but
+  /// this handles the common case.
+  pub fn duration(&self) -> Option<f64> {
+    self.inputs[0].duration
+  }
+}
+
 impl FfmpegIterator {
   pub fn new(child: &mut FfmpegChild) -> Result<Self> {
     let stderr = child.take_stderr().ok_or_else(|| Error::msg("No stderr channel\n - Did you call `take_stderr` elsewhere?\n - Did you forget to call `.stderr(Stdio::piped)` on the `ChildProcess`?"))?;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -156,6 +156,8 @@ impl FfmpegIterator {
       FfmpegEvent::OutputFrame(_) => None,
       FfmpegEvent::OutputChunk(_) => None,
       FfmpegEvent::Done => None,
+      FfmpegEvent::ParsedInput(input) => Some(input.raw_log_message),
+      FfmpegEvent::ParsedDuration(duration) => Some(duration.raw_log_message),
     })
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod error;
 pub mod event;
 pub mod iter;
 pub mod log_parser;
+pub mod metadata;
 pub mod paths;
 pub mod pix_fmt;
 pub mod read_until_any;

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -436,9 +436,8 @@ mod tests {
     let stdout = cmd.stdout.unwrap();
     let mut parser = FfmpegLogParser::new(stdout);
     while let Ok(event) = parser.parse_next_event() {
-      match event {
-        FfmpegEvent::ParsedVersion(_) => return,
-        _ => {}
+      if let FfmpegEvent::ParsedVersion(_) = event {
+        return;
       }
     }
     panic!() // should have found a version
@@ -456,9 +455,8 @@ mod tests {
     let stdout = cmd.stdout.unwrap();
     let mut parser = FfmpegLogParser::new(stdout);
     while let Ok(event) = parser.parse_next_event() {
-      match event {
-        FfmpegEvent::ParsedConfiguration(_) => return,
-        _ => {}
+      if let FfmpegEvent::ParsedConfiguration(_) = event {
+        return;
       }
     }
     panic!() // should have found a configuration

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,73 @@
+use crate::error::Result;
+use crate::event::{AVStream, FfmpegEvent, FfmpegInput, FfmpegOutput};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FfmpegMetadata {
+  expected_output_streams: usize,
+  pub outputs: Vec<FfmpegOutput>,
+  pub output_streams: Vec<AVStream>,
+  pub inputs: Vec<FfmpegInput>,
+  pub input_streams: Vec<AVStream>,
+
+  /// Whether all metadata from the parent process has been gathered into this struct
+  completed: bool,
+}
+
+impl Default for FfmpegMetadata {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl FfmpegMetadata {
+  pub fn new() -> Self {
+    Self {
+      expected_output_streams: 0,
+      outputs: Vec::new(),
+      output_streams: Vec::new(),
+      inputs: Vec::new(),
+      input_streams: Vec::new(),
+      completed: false,
+    }
+  }
+
+  pub fn is_completed(&self) -> bool {
+    self.completed
+  }
+
+  /// A shortcut to obtain the expected duration (in seconds).
+  ///
+  /// Usually this is the duration of the first input stream. Theoretically
+  /// different streams could have different (or conflicting) durations, but
+  /// this handles the common case.
+  pub fn duration(&self) -> Option<f64> {
+    self.inputs[0].duration
+  }
+
+  pub fn handle_event(&mut self, item: &Option<FfmpegEvent>) -> Result<()> {
+    if self.is_completed() {
+      return Err("Metadata is already completed".into());
+    }
+
+    match item {
+      // Every stream mapping corresponds to one output stream
+      // We count these to know when we've received all the output streams
+      Some(FfmpegEvent::ParsedStreamMapping(_)) => self.expected_output_streams += 1,
+      Some(FfmpegEvent::ParsedInput(input)) => self.inputs.push(input.clone()),
+      Some(FfmpegEvent::ParsedOutput(output)) => self.outputs.push(output.clone()),
+      Some(FfmpegEvent::ParsedDuration(duration)) => {
+        self.inputs[duration.input_index as usize].duration = Some(duration.duration)
+      }
+      Some(FfmpegEvent::ParsedOutputStream(stream)) => self.output_streams.push(stream.clone()),
+      Some(FfmpegEvent::ParsedInputStream(stream)) => self.input_streams.push(stream.clone()),
+      _ => (),
+    }
+
+    if self.expected_output_streams > 0 && self.output_streams.len() == self.expected_output_streams
+    {
+      self.completed = true;
+    }
+
+    Ok(())
+  }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -186,14 +186,21 @@ fn test_chunks_with_audio() {
 }
 
 #[test]
-/// TODO This test is order-dependent, relying on input from `test_to_file`.
-/// A better implementation would be use a future `pipeTo` method to generate
-/// its input in-memory in realtime.
 fn test_duration() {
+  // Prepare the input file.
+  // TODO construct this in-memory instead of writing to disk.
+  FfmpegCommand::new()
+    .args("-f lavfi -i testsrc=duration=5:rate=1 -y output/test_duration.mp4".split(' '))
+    .spawn()
+    .unwrap()
+    .iter()
+    .unwrap()
+    .count();
+
   let mut duration_received = false;
 
   FfmpegCommand::new()
-    .input("output/test.mp4")
+    .input("output/test_duration.mp4")
     .format("mpegts")
     .pipe_stdout()
     .spawn()
@@ -216,12 +223,19 @@ fn test_duration() {
 }
 
 #[test]
-/// TODO This test is order-dependent, relying on input from `test_to_file`.
-/// A better implementation would be use a future `pipeTo` method to generate
-/// its input in-memory in realtime.
 fn test_metadata_duration() {
+  // Prepare the input file.
+  // TODO construct this in-memory instead of writing to disk.
+  FfmpegCommand::new()
+    .args("-f lavfi -i testsrc=duration=5:rate=1 -y output/test_metadata_duration.mp4".split(' '))
+    .spawn()
+    .unwrap()
+    .iter()
+    .unwrap()
+    .count();
+
   let mut child = FfmpegCommand::new()
-    .input("output/test.mp4")
+    .input("output/test_metadata_duration.mp4")
     .format("mpegts")
     .pipe_stdout()
     .spawn()

--- a/src/test.rs
+++ b/src/test.rs
@@ -201,7 +201,6 @@ fn test_duration() {
     .unwrap()
     .for_each(|e| {
       if let FfmpegEvent::ParsedDuration(duration) = e {
-        println!("Duration: {:?}", duration);
         match duration_received {
           false => {
             assert!(duration.duration == 5.0);

--- a/src/test.rs
+++ b/src/test.rs
@@ -229,7 +229,8 @@ fn test_metadata_duration() {
 
   let metadata = child.iter().unwrap().collect_metadata().unwrap();
   child.kill().unwrap();
-  assert!(!metadata.inputs.is_empty());
+
+  assert!(metadata.duration() == Some(5.0));
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -204,15 +204,11 @@ fn test_duration() {
     .iter()
     .unwrap()
     .for_each(|e| {
-      match &e {
-        FfmpegEvent::OutputFrame(_) | FfmpegEvent::OutputChunk(_) => {}
-        e => println!("{:?}", e),
-      }
       if let FfmpegEvent::ParsedDuration(duration) = e {
         println!("Duration: {:?}", duration);
         match duration_received {
           false => {
-            assert!(duration.duration == 10.0);
+            assert!(duration.duration == 5.0);
             duration_received = true
           }
           true => panic!("Received multiple duration events."),

--- a/src/test.rs
+++ b/src/test.rs
@@ -194,6 +194,7 @@ fn test_duration() {
 
   FfmpegCommand::new()
     .input("output/test.mp4")
+    .format("mpegts")
     .pipe_stdout()
     .spawn()
     .unwrap()
@@ -212,6 +213,23 @@ fn test_duration() {
     });
 
   assert!(duration_received);
+}
+
+#[test]
+/// TODO This test is order-dependent, relying on input from `test_to_file`.
+/// A better implementation would be use a future `pipeTo` method to generate
+/// its input in-memory in realtime.
+fn test_metadata_duration() {
+  let mut child = FfmpegCommand::new()
+    .input("output/test.mp4")
+    .format("mpegts")
+    .pipe_stdout()
+    .spawn()
+    .unwrap();
+
+  let metadata = child.iter().unwrap().collect_metadata().unwrap();
+  child.kill().unwrap();
+  assert!(!metadata.inputs.is_empty());
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -36,10 +36,7 @@ fn test_frame_count() {
     .unwrap();
 
   let frame_count = iter
-    .filter(|event| match event {
-      FfmpegEvent::OutputFrame(_) => true,
-      _ => false,
-    })
+    .filter(|event| matches!(event, FfmpegEvent::OutputFrame(_)))
     .count();
 
   assert_eq!(frame_count, expected_frame_count);
@@ -53,12 +50,11 @@ fn test_output_format() {
     .unwrap()
     .iter()
     .unwrap()
-    .for_each(|event| match event {
-      FfmpegEvent::OutputFrame(frame) => {
+    .for_each(|event| {
+      if let FfmpegEvent::OutputFrame(frame) = event {
         assert!(frame.pix_fmt == "rgb24");
         assert!(frame.data.len() as u32 == frame.width * frame.height * 3);
       }
-      _ => {}
     });
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,8 +4,8 @@ use crate::{
   log_parser::FfmpegLogParser,
   paths::ffmpeg_path,
 };
-use std::process::{Command, Stdio};
 use std::ffi::OsStr;
+use std::process::{Command, Stdio};
 
 /// Alias for `ffmpeg -version`, parsing the version number and returning it.
 pub fn ffmpeg_version() -> Result<String> {
@@ -34,5 +34,5 @@ pub fn ffmpeg_version_with_path<S: AsRef<OsStr>>(path: S) -> Result<String> {
   if !exit_status.success() {
     return Err(Error::msg("ffmpeg -version exited with non-zero status"));
   }
-  version.ok_or(Error::msg("Failed to parse ffmpeg version"))
+  version.ok_or_else(|| Error::msg("Failed to parse ffmpeg version"))
 }


### PR DESCRIPTION
- Determine expected output duration from metadata
- Parse FFmpeg time/duration strings with `parse_time_str`
- Improve error handling in `collect_metadata` to "bubble up" errors from inside the iterator