### PR TITLE
feat: Added wait method on FfmpegChild

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -1,6 +1,6 @@
 use std::{
   io::{self, Write},
-  process::{Child, ChildStderr, ChildStdin, ChildStdout},
+  process::{Child, ChildStderr, ChildStdin, ChildStdout, ExitStatus},
 };
 
 use crate::error::{Error, Result};
@@ -95,6 +95,13 @@ impl FfmpegChild {
   /// Identical to `kill` in [`std::process::Child`].
   pub fn kill(&mut self) -> io::Result<()> {
     self.inner.kill()
+  }
+
+  /// Waits for the inner child process to finish execution.
+  ///
+  /// Identical to `wait` in [`std::process::Child`].
+  pub fn wait(&mut self) -> io::Result<ExitStatus> {
+    self.inner.wait()
   }
 
   /// Wrap a [`std::process::Child`] in a `FfmpegChild`. Should typically only

--- a/src/command.rs
+++ b/src/command.rs
@@ -554,6 +554,10 @@ impl FfmpegCommand {
   /// Spawn the ffmpeg command as a child process, wrapping it in a
   /// `FfmpegChild` interface.
   ///
+  /// Please note that if the result is not used with [wait()](FfmpegChild::wait)
+  /// the process is not cleaned up correctly resulting in a zombie process
+  /// until your main thread exits.
+  ///
   /// Identical to `spawn` in [`std::process::Command`].
   pub fn spawn(&mut self) -> io::Result<FfmpegChild> {
     self.inner.spawn().map(FfmpegChild::from_inner)


### PR DESCRIPTION
Every call to `spawn` without a call on the Result to `wait` results in a zombie process that stays until the main thread exits. This lead to OS issues with large datasets because it is possible that all PID's are used by the zombies.

This PR exposes the `wait` method of `std::process::Child` to the user, giving the possibility to wait for the process to complete and clean up properly.

It has only been tested on Linux.

I am happy to further adjust the code to your coding/documentation style requirements.

Best regards,
Lewin