### PR TITLE
update macos runners

### DIFF
--- a/.github/workflows/mac-m1.yml
+++ b/.github/workflows/mac-m1.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose -- --skip lib.rs

--- a/.github/workflows/mac-m1.yml
+++ b/.github/workflows/mac-m1.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Try auto-download
-        run: cargo run --example download_ffmpeg
+        run: cargo run --example download_ffmpeg -- ../deps
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/.github/workflows/mac-m1.yml
+++ b/.github/workflows/mac-m1.yml
@@ -20,3 +20,5 @@ jobs:
         run: cargo run --example download_ffmpeg
       - name: Build
         run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/mac-m1.yml
+++ b/.github/workflows/mac-m1.yml
@@ -11,8 +11,8 @@ env:
 
 jobs:
   build:
-    # https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/
-    runs-on: macos-13-xlarge
+    # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,24 +2,23 @@ name: Mac
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: FedericoCarboni/setup-ffmpeg@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Try auto-download
-      run: cargo run --example download_ffmpeg
+      - uses: actions/checkout@v3
+      - uses: FedericoCarboni/setup-ffmpeg@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Try auto-download
+        run: cargo run --example download_ffmpeg

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,24 +2,23 @@ name: Ubuntu
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: FedericoCarboni/setup-ffmpeg@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Try auto-download
-      run: cargo run --example download_ffmpeg
+      - uses: actions/checkout@v3
+      - uses: FedericoCarboni/setup-ffmpeg@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Try auto-download
+        run: cargo run --example download_ffmpeg

--- a/examples/download_ffmpeg.rs
+++ b/examples/download_ffmpeg.rs
@@ -2,11 +2,11 @@ use ffmpeg_sidecar::{
   command::ffmpeg_is_installed,
   download::{check_latest_version, download_ffmpeg_package, ffmpeg_download_url, unpack_ffmpeg},
   paths::sidecar_dir,
-  version::ffmpeg_version,
+  version::ffmpeg_version_with_path,
 };
 use std::{
   env::current_exe,
-  path::{self, Component, Path, PathBuf},
+  path::{Component, PathBuf},
 };
 
 fn main() -> anyhow::Result<()> {
@@ -48,7 +48,7 @@ fn main() -> anyhow::Result<()> {
   unpack_ffmpeg(&archive_path, &destination)?;
 
   // Use the freshly installed FFmpeg to check the version number
-  let version = ffmpeg_version()?;
+  let version = ffmpeg_version_with_path(destination.join("ffmpeg"))?;
   println!("FFmpeg version: {}", version);
 
   println!("Done! 🏁");

--- a/examples/download_ffmpeg.rs
+++ b/examples/download_ffmpeg.rs
@@ -4,6 +4,7 @@ use ffmpeg_sidecar::{
   paths::sidecar_dir,
   version::ffmpeg_version,
 };
+use std::{env::current_exe, path};
 
 fn main() -> anyhow::Result<()> {
   if ffmpeg_is_installed() {
@@ -27,7 +28,11 @@ fn main() -> anyhow::Result<()> {
   // These defaults will automatically select the correct download URL for your
   // platform.
   let download_url = ffmpeg_download_url()?;
-  let destination = sidecar_dir()?;
+  let cli_arg = std::env::args().nth(1);
+  let destination = match cli_arg {
+    Some(arg) => path::absolute(current_exe()?.parent().unwrap().join(arg))?,
+    None => sidecar_dir()?,
+  };
 
   // By default the download will use a `curl` command. You could also write
   // your own download function and use another package like `reqwest` instead.

--- a/src/download.rs
+++ b/src/download.rs
@@ -39,7 +39,7 @@ pub fn ffmpeg_download_url() -> anyhow::Result<&'static str> {
   } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
     Ok("https://evermeet.cx/ffmpeg/getrelease")
   } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-    Ok("https://www.osxexperts.net/ffmpeg6arm.zip") // Mac M1
+    Ok("https://www.osxexperts.net/ffmpeg7arm.zip") // Mac M1
   } else {
     anyhow::bail!("Unsupported platform; you can provide your own URL instead and call download_ffmpeg_package directly.")
   }
@@ -115,10 +115,7 @@ pub fn curl(url: &str) -> anyhow::Result<String> {
     .stdout(Stdio::piped())
     .spawn()?;
 
-  let stdout = child
-    .stdout
-    .take()
-    .context("Failed to get stdout")?;
+  let stdout = child.stdout.take().context("Failed to get stdout")?;
 
   let mut string = String::new();
   std::io::BufReader::new(stdout).read_to_string(&mut string)?;
@@ -159,9 +156,7 @@ pub fn download_ffmpeg_package(url: &str, download_dir: &Path) -> anyhow::Result
 
   let archive_path = download_dir.join(filename);
 
-  let archive_filename = archive_path
-    .to_str()
-    .context("invalid download path")?;
+  let archive_filename = archive_path.to_str().context("invalid download path")?;
 
   let exit_status = curl_to_file(url, archive_filename)?;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,6 @@
 use crate::{
   command::{ffmpeg_is_installed, FfmpegCommand},
   event::FfmpegEvent,
-  ffprobe::{ffprobe_path, ffprobe_version},
   version::ffmpeg_version,
 };
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -301,12 +301,6 @@ fn test_frame_timestamp() {
 }
 
 #[test]
-fn test_ffprobe_version() {
-  println!("{:?}", ffprobe_path());
-  println!("{:?}", ffprobe_version().unwrap());
-}
-
-#[test]
 fn test_filter_complex() {
   let num_frames = FfmpegCommand::new()
     .format("lavfi")


### PR DESCRIPTION
- [x] Update Github Actions runners for Mac and Mac M1
- [x] Add an optional download path argument to the `download_ffmpeg` example to support running tests on Mac M1
- [x] Remove an empty FFprobe unit test (FFprobe is not downloaded on M1) 
- [x] Disable `lib` test which assumes FFmpeg in PATH (only on Mac M1)
- [x] Update Mac M1 auto download to FFmpeg v7.0