### PR TITLE
fix: apply windows creation flags to all command subprocesses

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -7,7 +7,10 @@ use std::{
 
 use anyhow::Context;
 
-use crate::{command::ffmpeg_is_installed, paths::sidecar_dir};
+use crate::{
+  command::{ffmpeg_is_installed, BackgroundCommand},
+  paths::sidecar_dir,
+};
 
 pub const UNPACK_DIRNAME: &str = "ffmpeg_release_temp";
 
@@ -110,6 +113,7 @@ pub fn parse_linux_version(version: &str) -> Option<String> {
 /// Invoke cURL on the command line to download a file, returning it as a string.
 pub fn curl(url: &str) -> anyhow::Result<String> {
   let mut child = Command::new("curl")
+    .create_no_window()
     .args(["-L", url])
     .stderr(Stdio::null())
     .stdout(Stdio::piped())
@@ -125,6 +129,7 @@ pub fn curl(url: &str) -> anyhow::Result<String> {
 /// Invoke cURL on the command line to download a file, writing to a file.
 pub fn curl_to_file(url: &str, destination: &str) -> anyhow::Result<ExitStatus> {
   Command::new("curl")
+    .create_no_window()
     .args(["-L", url])
     .args(["-o", destination])
     .status()
@@ -180,6 +185,7 @@ pub fn unpack_ffmpeg(from_archive: &PathBuf, binary_folder: &Path) -> anyhow::Re
 
   // Extract archive
   Command::new("tar")
+    .create_no_window()
     .arg("-xf")
     .arg(from_archive)
     .current_dir(&temp_folder)

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -43,7 +43,10 @@ pub fn ffprobe_version() -> anyhow::Result<String> {
 /// Lower level variant of `ffprobe_version` that exposes a customized the path
 /// to the ffmpeg binary.
 pub fn ffprobe_version_with_path<S: AsRef<OsStr>>(path: S) -> anyhow::Result<String> {
-  let output = Command::new(&path).arg("-version").output()?;
+  let output = Command::new(&path)
+    .arg("-version")
+    .create_no_window()
+    .output()?;
 
   // note:version parsing is not implemented for ffprobe
 

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -1,10 +1,10 @@
+use crate::command::BackgroundCommand;
+use anyhow::Context;
 use std::{env::current_exe, ffi::OsStr, path::PathBuf};
 use std::{
   path::Path,
   process::{Command, Stdio},
 };
-
-use anyhow::Context;
 
 /// Returns the path of the downloaded FFprobe executable, or falls back to
 /// assuming its installed in the system path. Note that not all FFmpeg
@@ -55,6 +55,7 @@ pub fn ffprobe_version_with_path<S: AsRef<OsStr>>(path: S) -> anyhow::Result<Str
 /// executable.
 pub fn ffprobe_is_installed() -> bool {
   Command::new(ffprobe_path())
+    .create_no_window()
     .arg("-version")
     .stderr(Stdio::null())
     .stdout(Stdio::null())

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -499,7 +499,7 @@ pub fn parse_time_str(str: &str) -> Option<f64> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::paths::ffmpeg_path;
+  use crate::{command::BackgroundCommand, paths::ffmpeg_path};
   use std::{
     io::{Cursor, Seek, SeekFrom, Write},
     process::{Command, Stdio},
@@ -508,6 +508,7 @@ mod tests {
   #[test]
   fn test_parse_version() {
     let cmd = Command::new(ffmpeg_path())
+      .create_no_window()
       .arg("-version")
       .stdout(Stdio::piped())
       // ⚠ notice that ffmpeg emits on stdout when `-version` or `-help` is passed!
@@ -527,6 +528,7 @@ mod tests {
   #[test]
   fn test_parse_configuration() {
     let cmd = Command::new(ffmpeg_path())
+      .create_no_window()
       .arg("-version")
       .stdout(Stdio::piped())
       // ⚠ notice that ffmpeg emits on stdout when `-version` or `-help` is passed!

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,10 +1,7 @@
 use anyhow::Context;
 
-use crate::{
-  event::FfmpegEvent,
-  log_parser::FfmpegLogParser,
-  paths::ffmpeg_path,
-};
+use crate::command::BackgroundCommand;
+use crate::{event::FfmpegEvent, log_parser::FfmpegLogParser, paths::ffmpeg_path};
 use std::ffi::OsStr;
 use std::process::{Command, Stdio};
 
@@ -13,10 +10,11 @@ pub fn ffmpeg_version() -> anyhow::Result<String> {
   ffmpeg_version_with_path(ffmpeg_path())
 }
 
-/// Lower level variant of `ffmpeg_version` that exposes a customized the path
+/// Lower level variant of `ffmpeg_version` that exposes a customized path
 /// to the ffmpeg binary.
 pub fn ffmpeg_version_with_path<S: AsRef<OsStr>>(path: S) -> anyhow::Result<String> {
   let mut cmd = Command::new(&path)
+    .create_no_window()
     .arg("-version")
     .stdout(Stdio::piped()) // not stderr when calling `-version`
     .spawn()?;


### PR DESCRIPTION
Fixes #40 

- [x] Apply `create_no_window` by default in `FfmpegCommand` constructor
  - The user can still override this before `spawn()` by using the `CommandExt::creation_flags` method directly
- [x] Extend the `create_no_window` method introduced in #7 
  - Provides an internal extension trait on all `Command`'s that conditionally applies the right creation flags only on Windows
  - Apply that method on every `Command` used in the library, including `curl()`, `unpack_ffmpeg()`, `ffmpeg_version()`, etc