### PR TITLE
Removed curl dependency with reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,14 @@ repository = "https://github.com/nathanbabcock/ffmpeg-sidecar"
 readme = "README.md"
 license = "MIT"
 
+[features]
+default = ["download_ffmpeg"]
+download_ffmpeg = ["reqwest"]
+
 [lib]
 crate-type = ["lib"]
 
 [dependencies]
 anyhow = "1.0.79"
+reqwest = { version = "0.12.8", optional = true, features = ["blocking"]}
+

--- a/src/download.rs
+++ b/src/download.rs
@@ -113,6 +113,7 @@ pub fn parse_linux_version(version: &str) -> Option<String> {
 
 /// Makes an HTTP request to obtain the latest version available online,
 /// automatically choosing the correct URL for the current platform.
+#[cfg(feature = "download_ffmpeg")]
 pub fn check_latest_version() -> anyhow::Result<String> {
   // Mac M1 doesn't have a manifest URL, so match the version provided in `ffmpeg_download_url`
   if cfg!(all(target_os = "macos", target_arch = "aarch64")) {

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,5 +1,6 @@
 use std::{
-  fs::{create_dir_all, read_dir, remove_dir_all, remove_file, rename},
+  fs::{create_dir_all, read_dir, remove_dir_all, remove_file, rename, File},
+  io,
   path::{Path, PathBuf},
   process::Command,
 };
@@ -160,9 +161,9 @@ pub fn download_ffmpeg_package(url: &str, download_dir: &Path) -> anyhow::Result
   }
 
   let mut file =
-    std::fs::File::create(&archive_path).context("Failed to create file for ffmpeg download")?;
+    File::create(&archive_path).context("Failed to create file for ffmpeg download")?;
 
-  std::io::copy(
+  io::copy(
     &mut response
       .bytes()
       .context("Failed to read response bytes")?


### PR DESCRIPTION
**Steps I have taken:**

- Used the reqwest blocking feature to download files .

**Potential Concerns:**

- Currently, the ffmpeg is not downloaded using streaming
- To stream download the file, I think we have to create async download function. ( I personally didn't wanted to go for the async thing, becauase the whole library is not using async )
- For the download progress feature, we need to stream download the file, which is not done in this PR.

**Personal Feelings ( My Personal Opinion only )**

- I think the download progress feature should not be a part of this library, just feels it is out of scope of this library's utility, users can implement their own download progress feature or use another library for it .

Maintainer, feel free to suggest different approach ..