### PR TITLE
feat!: Add audio and subtitle stream parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,38 +90,37 @@ use ffmpeg_sidecar::{command::FfmpegCommand, event::FfmpegEvent};
 
 fn main() -> anyhow::Result<()> {
   FfmpegCommand::new() // <- Builder API like `std::process::Command`
-    .testsrc() // <- Discoverable aliases for FFmpeg args
-    .rawvideo() // <- Convenient argument presets
-    .spawn()? // <- Uses an ordinary `std::process::Child`
-    .iter()? // <- Iterator over all log messages and video output
-    .for_each(|event: FfmpegEvent| {
-      match event {
-        FfmpegEvent::OutputFrame(frame) => {
-          println!("frame: {}x{}", frame.width, frame.height);
-          let _pixels: Vec<u8> = frame.data; // <- raw RGB pixels! 🎨
-        }
-        FfmpegEvent::Progress(progress) => {
-          eprintln!("Current speed: {}x", progress.speed); // <- parsed progress updates
-        }
-        FfmpegEvent::Log(_level, msg) => {
-          eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
-        }
-        FfmpegEvent::ParsedInputStream(stream) => {
-          if stream.is_video() {
-            let video_data = stream.video_data();
-            println!(
-              "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
-              stream.stream_index,
-              stream.parent_index,
-              video_data.fps,
-              video_data.width,
-              video_data.height
-            );
+      .testsrc() // <- Discoverable aliases for FFmpeg args
+      .rawvideo() // <- Convenient argument presets
+      .spawn()? // <- Uses an ordinary `std::process::Child`
+      .iter()? // <- Iterator over all log messages and video output
+      .for_each(|event: FfmpegEvent| {
+        match event {
+          FfmpegEvent::OutputFrame(frame) => {
+            println!("frame: {}x{}", frame.width, frame.height);
+            let _pixels: Vec<u8> = frame.data; // <- raw RGB pixels! 🎨
           }
+          FfmpegEvent::Progress(progress) => {
+            eprintln!("Current speed: {}x", progress.speed); // <- parsed progress updates
+          }
+          FfmpegEvent::Log(_level, msg) => {
+            eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
+          }
+          FfmpegEvent::ParsedInputStream(stream) => {
+            if let Some(video_data) = stream.video_data() {
+              println!(
+                "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
+                stream.stream_index,
+                stream.parent_index,
+                video_data.fps,
+                video_data.width,
+                video_data.height
+              );
+            }
+          }
+          _ => {}
         }
-        _ => {}
-      }
-    });
+      });
   Ok(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ Read raw video frames.
 ```rust
 use ffmpeg_sidecar::{command::FfmpegCommand, event::FfmpegEvent};
 
-fn main() -> anyhow::Result<()> { 
+fn main() -> anyhow::Result<()> {
   FfmpegCommand::new() // <- Builder API like `std::process::Command`
-    .testsrc()  // <- Discoverable aliases for FFmpeg args
+    .testsrc() // <- Discoverable aliases for FFmpeg args
     .rawvideo() // <- Convenient argument presets
-    .spawn()?   // <- Uses an ordinary `std::process::Child`
-    .iter()?    // <- Iterator over all log messages and video output
+    .spawn()? // <- Uses an ordinary `std::process::Child`
+    .iter()? // <- Iterator over all log messages and video output
     .for_each(|event: FfmpegEvent| {
       match event {
         FfmpegEvent::OutputFrame(frame) => {
@@ -105,6 +105,19 @@ fn main() -> anyhow::Result<()> {
         }
         FfmpegEvent::Log(_level, msg) => {
           eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
+        }
+        FfmpegEvent::ParsedInputStream(stream) => {
+          if stream.is_video() {
+            let video_data = stream.video_data();
+            println!(
+              "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
+              stream.stream_index,
+              stream.parent_index,
+              video_data.fps,
+              video_data.width,
+              video_data.height
+            );
+          }
         }
         _ => {}
       }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -24,8 +24,7 @@ fn main() -> anyhow::Result<()> {
           eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
         }
         FfmpegEvent::ParsedInputStream(stream) => {
-          if stream.is_video() {
-            let video_data = stream.video_data();
+          if let Some(video_data) = stream.video_data() {
             println!(
               "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
               stream.stream_index,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -23,6 +23,19 @@ fn main() -> anyhow::Result<()> {
         FfmpegEvent::Log(_level, msg) => {
           eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
         }
+        FfmpegEvent::ParsedInputStream(stream) => {
+          if stream.is_video() {
+            let video_data = stream.video_data();
+            println!(
+              "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
+              stream.stream_index,
+              stream.parent_index,
+              video_data.fps,
+              video_data.width,
+              video_data.height
+            );
+          }
+        }
         _ => {}
       }
     });

--- a/src/event.rs
+++ b/src/event.rs
@@ -90,18 +90,16 @@ impl Stream {
     matches!(self.type_specific_data, TypeSpecificData::Other())
   }
 
-  pub fn audio_data(&self) -> AudioStream {
-    if let TypeSpecificData::Audio(audio_stream) = &self.type_specific_data {
-      audio_stream.clone()
-    } else {
-      panic!("This is not an audio stream! Check `stream.is_audio()` before calling this method.");
+  pub fn audio_data(&self) -> Option<&AudioStream> {
+    match &self.type_specific_data {
+      TypeSpecificData::Audio(audio_stream) => Some(audio_stream),
+      _ => None,
     }
   }
-  pub fn video_data(&self) -> VideoStream {
-    if let TypeSpecificData::Video(video_stream) = &self.type_specific_data {
-      video_stream.clone()
-    } else {
-      panic!("This is not a video stream! Check `stream.is_video()` before calling this method.");
+  pub fn video_data(&self) -> Option<&VideoStream> {
+    match &self.type_specific_data {
+      TypeSpecificData::Video(video_stream) => Some(video_stream),
+      _ => None,
     }
   }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,8 +5,8 @@ pub enum FfmpegEvent {
   ParsedStreamMapping(String),
   ParsedInput(FfmpegInput),
   ParsedOutput(FfmpegOutput),
-  ParsedInputStream(AVStream),
-  ParsedOutputStream(AVStream),
+  ParsedInputStream(Stream),
+  ParsedOutputStream(Stream),
   ParsedDuration(FfmpegDuration),
   Log(LogLevel, String),
   LogEOF,
@@ -59,12 +59,76 @@ impl FfmpegOutput {
   }
 }
 
+/// Represents metadata about a stream.
 #[derive(Debug, Clone, PartialEq)]
-pub struct AVStream {
-  /// Typically `video` or `audio`, but might be something else like `data` or `subtitle`.
-  pub stream_type: String,
-  /// Corresponds to stream `-f` parameter, e.g. `rawvideo`, `h264`, or `mpegts`
+pub struct Stream {
+  /// Corresponds to stream `-f` parameter, e.g. `rawvideo`, `h264`, `opus` or `srt`.
   pub format: String,
+  // The language of the stream as a three letter code such as `eng`, `ger` or `jpn`.
+  pub language: String,
+  /// The index of the input or output that this stream belongs to.
+  pub parent_index: usize,
+  /// The index of the stream inside the input.
+  pub stream_index: usize,
+  /// The stderr line that this stream was parsed from.
+  pub raw_log_message: String,
+  // Data that is specific to a certain stream type.
+  pub type_specific_data: TypeSpecificData,
+}
+
+impl Stream {
+  pub fn is_audio(&self) -> bool {
+    matches!(self.type_specific_data, TypeSpecificData::Audio(_))
+  }
+  pub fn is_subtitle(&self) -> bool {
+    matches!(self.type_specific_data, TypeSpecificData::Subtitle())
+  }
+  pub fn is_video(&self) -> bool {
+    matches!(self.type_specific_data, TypeSpecificData::Video(_))
+  }
+  pub fn is_other(&self) -> bool {
+    matches!(self.type_specific_data, TypeSpecificData::Other())
+  }
+
+  pub fn audio_data(&self) -> AudioStream {
+    if let TypeSpecificData::Audio(audio_stream) = &self.type_specific_data {
+      audio_stream.clone()
+    } else {
+      panic!("This is not an audio stream! Check `stream.is_audio()` before calling this method.");
+    }
+  }
+  pub fn video_data(&self) -> VideoStream {
+    if let TypeSpecificData::Video(video_stream) = &self.type_specific_data {
+      video_stream.clone()
+    } else {
+      panic!("This is not a video stream! Check `stream.is_video()` before calling this method.");
+    }
+  }
+}
+
+/// Represents metadata that is specific to a stream, e.g. fields that are only found in audio
+/// streams or that are only found in video streams, etc. Storing this in an enum allows function to
+/// accept the generic `Stream` type regardless of its actual type (audio, video, ...).
+#[derive(Debug, Clone, PartialEq)]
+pub enum TypeSpecificData {
+  Audio(AudioStream),
+  Video(VideoStream),
+  Subtitle(),
+  Other(),
+}
+
+/// Represents metadata that is specific to audio streams.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AudioStream {
+  /// The sample rate of the audio stream, e.g. 48000 (Hz)
+  pub sample_rate: usize,
+  /// The number of channels of the audio stream, e.g. `stereo`, `5.1` or `7.1`
+  pub channels: String,
+}
+
+/// Represents metadata that is specific to video streams.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VideoStream {
   /// Corresponds to stream `-pix_fmt` parameter, e.g. `rgb24`
   pub pix_fmt: String,
   /// Width in pixels
@@ -73,10 +137,6 @@ pub struct AVStream {
   pub height: u32,
   /// Framerate in frames per second
   pub fps: f32,
-  /// The index of the input or output that this stream belongs to
-  pub parent_index: usize,
-  /// The stderr line that this stream was parsed from
-  pub raw_log_message: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -67,9 +67,9 @@ pub struct Stream {
   // The language of the stream as a three letter code such as `eng`, `ger` or `jpn`.
   pub language: String,
   /// The index of the input or output that this stream belongs to.
-  pub parent_index: usize,
+  pub parent_index: u32,
   /// The index of the stream inside the input.
-  pub stream_index: usize,
+  pub stream_index: u32,
   /// The stderr line that this stream was parsed from.
   pub raw_log_message: String,
   // Data that is specific to a certain stream type.
@@ -119,7 +119,7 @@ pub enum TypeSpecificData {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AudioStream {
   /// The sample rate of the audio stream, e.g. 48000 (Hz)
-  pub sample_rate: usize,
+  pub sample_rate: u32,
   /// The number of channels of the audio stream, e.g. `stereo`, `5.1` or `7.1`
   pub channels: String,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -73,32 +73,32 @@ pub struct Stream {
   /// The stderr line that this stream was parsed from.
   pub raw_log_message: String,
   // Data that is specific to a certain stream type.
-  pub type_specific_data: TypeSpecificData,
+  pub type_specific_data: StreamTypeSpecificData,
 }
 
 impl Stream {
   pub fn is_audio(&self) -> bool {
-    matches!(self.type_specific_data, TypeSpecificData::Audio(_))
+    matches!(self.type_specific_data, StreamTypeSpecificData::Audio(_))
   }
   pub fn is_subtitle(&self) -> bool {
-    matches!(self.type_specific_data, TypeSpecificData::Subtitle())
+    matches!(self.type_specific_data, StreamTypeSpecificData::Subtitle())
   }
   pub fn is_video(&self) -> bool {
-    matches!(self.type_specific_data, TypeSpecificData::Video(_))
+    matches!(self.type_specific_data, StreamTypeSpecificData::Video(_))
   }
   pub fn is_other(&self) -> bool {
-    matches!(self.type_specific_data, TypeSpecificData::Other())
+    matches!(self.type_specific_data, StreamTypeSpecificData::Other())
   }
 
   pub fn audio_data(&self) -> Option<&AudioStream> {
     match &self.type_specific_data {
-      TypeSpecificData::Audio(audio_stream) => Some(audio_stream),
+      StreamTypeSpecificData::Audio(audio_stream) => Some(audio_stream),
       _ => None,
     }
   }
   pub fn video_data(&self) -> Option<&VideoStream> {
     match &self.type_specific_data {
-      TypeSpecificData::Video(video_stream) => Some(video_stream),
+      StreamTypeSpecificData::Video(video_stream) => Some(video_stream),
       _ => None,
     }
   }
@@ -108,7 +108,7 @@ impl Stream {
 /// streams or that are only found in video streams, etc. Storing this in an enum allows function to
 /// accept the generic `Stream` type regardless of its actual type (audio, video, ...).
 #[derive(Debug, Clone, PartialEq)]
-pub enum TypeSpecificData {
+pub enum StreamTypeSpecificData {
   Audio(AudioStream),
   Video(VideoStream),
   Subtitle(),

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -191,7 +191,7 @@ pub fn spawn_stdout_thread(
       .filter(|stream| stream.is_video())
       .filter(|stream| {
         outputs
-          .get(stream.parent_index)
+          .get(stream.parent_index as usize)
           .map(|o| o.is_stdout())
           .unwrap_or(false)
       });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,29 +5,42 @@
 //! ```rust
 //! use ffmpeg_sidecar::{command::FfmpegCommand, event::FfmpegEvent};
 //!
-//! fn main() -> anyhow::Result<()> {
-//!   FfmpegCommand::new() // <- Builder API like `std::process::Command`
-//!     .testsrc()  // <- Discoverable aliases for FFmpeg args
-//!     .rawvideo() // <- Convenient argument presets
-//!     .spawn()?   // <- Uses an ordinary `std::process::Child`
-//!     .iter()?    // <- Iterator over all log messages and video output
-//!     .for_each(|event: FfmpegEvent| {
-//!       match event {
-//!         FfmpegEvent::OutputFrame(frame) => {
-//!           println!("frame: {}x{}", frame.width, frame.height);
-//!           let _pixels: Vec<u8> = frame.data; // <- raw RGB pixels! 🎨
-//!         }
-//!         FfmpegEvent::Progress(progress) => {
-//!           eprintln!("Current speed: {}x", progress.speed); // <- parsed progress updates
-//!         }
-//!         FfmpegEvent::Log(_level, msg) => {
-//!           eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
-//!         }
-//!         _ => {}
-//!       }
-//!     });
-//!   Ok(())
-//! }
+//!fn main() -> anyhow::Result<()> {
+//!    FfmpegCommand::new() // <- Builder API like `std::process::Command`
+//!      .testsrc() // <- Discoverable aliases for FFmpeg args
+//!      .rawvideo() // <- Convenient argument presets
+//!      .spawn()? // <- Uses an ordinary `std::process::Child`
+//!      .iter()? // <- Iterator over all log messages and video output
+//!      .for_each(|event: FfmpegEvent| {
+//!        match event {
+//!          FfmpegEvent::OutputFrame(frame) => {
+//!            println!("frame: {}x{}", frame.width, frame.height);
+//!            let _pixels: Vec<u8> = frame.data; // <- raw RGB pixels! 🎨
+//!          }
+//!          FfmpegEvent::Progress(progress) => {
+//!            eprintln!("Current speed: {}x", progress.speed); // <- parsed progress updates
+//!          }
+//!          FfmpegEvent::Log(_level, msg) => {
+//!            eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
+//!          }
+//!          FfmpegEvent::ParsedInputStream(stream) => {
+//!            if stream.is_video() {
+//!              let video_data = stream.video_data();
+//!              println!(
+//!                "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
+//!                stream.stream_index,
+//!                stream.parent_index,
+//!                video_data.fps,
+//!                video_data.width,
+//!                video_data.height
+//!              );
+//!            }
+//!          }
+//!          _ => {}
+//!        }
+//!      });
+//!    Ok(())
+//!  }
 //! ```
 //!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! use ffmpeg_sidecar::{command::FfmpegCommand, event::FfmpegEvent};
 //!
 //!fn main() -> anyhow::Result<()> {
-//!    FfmpegCommand::new() // <- Builder API like `std::process::Command`
+//!  FfmpegCommand::new() // <- Builder API like `std::process::Command`
 //!      .testsrc() // <- Discoverable aliases for FFmpeg args
 //!      .rawvideo() // <- Convenient argument presets
 //!      .spawn()? // <- Uses an ordinary `std::process::Child`
@@ -24,8 +24,7 @@
 //!            eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
 //!          }
 //!          FfmpegEvent::ParsedInputStream(stream) => {
-//!            if stream.is_video() {
-//!              let video_data = stream.video_data();
+//!            if let Some(video_data) = stream.video_data() {
 //!              println!(
 //!                "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
 //!                stream.stream_index,
@@ -39,8 +38,8 @@
 //!          _ => {}
 //!        }
 //!      });
-//!    Ok(())
-//!  }
+//!  Ok(())
+//!}
 //! ```
 //!
 

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -417,7 +417,7 @@ pub fn try_parse_stream(string: &str) -> Option<Stream> {
   let mut comma_iter = CommaIter::new(&string);
   let mut colon_iter = comma_iter.next()?.split(':');
 
-  let parent_index = colon_iter.next()?.parse::<usize>().ok()?;
+  let parent_index = colon_iter.next()?.parse::<u32>().ok()?;
 
   // Here handle pattern such as `2[0x3](eng)`
   let indices_and_maybe_language = colon_iter
@@ -427,7 +427,7 @@ pub fn try_parse_stream(string: &str) -> Option<Stream> {
     .step_by(2)
     .collect::<String>();
   let mut parenthesis_iter = indices_and_maybe_language.split('(');
-  let stream_index = parenthesis_iter.next()?.trim().parse::<usize>().ok()?;
+  let stream_index = parenthesis_iter.next()?.trim().parse::<u32>().ok()?;
   let language = parenthesis_iter.next().map_or("".to_string(), |lang| {
     lang.trim_end_matches(')').to_string()
   });
@@ -466,7 +466,7 @@ fn try_parse_audio_stream(mut comma_iter: CommaIter) -> Option<TypeSpecificData>
     .trim()
     .split_whitespace()
     .next()?
-    .parse::<usize>()
+    .parse::<u32>()
     .ok()?;
 
   let channels = comma_iter.next()?.trim().to_string();

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -283,7 +283,7 @@ pub fn try_parse_output(mut string: &str) -> Option<FfmpegOutput> {
 /// assert!(stream.parent_index == 0);
 /// assert!(stream.stream_index == 0);
 /// assert!(stream.is_video());
-/// let video_data = stream.video_data();
+/// let video_data = stream.video_data().unwrap();
 /// assert!(video_data.pix_fmt == "rgb24");
 /// assert!(video_data.width == 320);
 /// assert!(video_data.height == 240);
@@ -301,7 +301,7 @@ pub fn try_parse_output(mut string: &str) -> Option<FfmpegOutput> {
 ///  assert!(stream.parent_index == 1);
 ///  assert!(stream.stream_index == 5);
 ///  assert!(stream.is_video());
-///  let video_data = stream.video_data();
+///  let video_data = stream.video_data().unwrap();
 ///  assert!(video_data.pix_fmt == "yuv444p");
 ///  assert!(video_data.width == 320);
 ///  assert!(video_data.height == 240);
@@ -321,7 +321,7 @@ pub fn try_parse_output(mut string: &str) -> Option<FfmpegOutput> {
 /// assert!(stream.parent_index == 0);
 /// assert!(stream.stream_index == 1);
 /// assert!(stream.is_audio());
-/// let audio_data = stream.audio_data();
+/// let audio_data = stream.audio_data().unwrap();
 /// assert!(audio_data.sample_rate == 48000);
 /// assert!(audio_data.channels == "stereo");
 /// ```
@@ -335,7 +335,7 @@ pub fn try_parse_output(mut string: &str) -> Option<FfmpegOutput> {
 /// assert!(stream.parent_index == 3);
 /// assert!(stream.stream_index == 10);
 /// assert!(stream.is_audio());
-/// let audio_data = stream.audio_data();
+/// let audio_data = stream.audio_data().unwrap();
 /// assert!(audio_data.sample_rate == 48000);
 /// assert!(audio_data.channels == "7.1");
 /// ```
@@ -351,7 +351,7 @@ pub fn try_parse_output(mut string: &str) -> Option<FfmpegOutput> {
 /// assert!(stream.parent_index == 10);
 /// assert!(stream.stream_index == 1);
 /// assert!(stream.is_audio());
-/// let audio_data = stream.audio_data();
+/// let audio_data = stream.audio_data().unwrap();
 /// assert!(audio_data.sample_rate == 44100);
 /// assert!(audio_data.channels == "mono");
 /// ```

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -6,8 +6,8 @@ use std::{
 use crate::{
   comma_iter::CommaIter,
   event::{
-    AVStream, FfmpegConfiguration, FfmpegDuration, FfmpegEvent, FfmpegInput, FfmpegOutput,
-    FfmpegProgress, FfmpegVersion, LogLevel,
+    AudioStream, FfmpegConfiguration, FfmpegDuration, FfmpegEvent, FfmpegInput, FfmpegOutput,
+    FfmpegProgress, FfmpegVersion, LogLevel, Stream, TypeSpecificData, VideoStream,
   },
   read_until_any::read_until_any,
 };
@@ -266,80 +266,219 @@ pub fn try_parse_output(mut string: &str) -> Option<FfmpegOutput> {
   })
 }
 
-/// ## Example
+/// Parses a line that represents a stream.
 ///
-/// ### Input stream:
+/// ## Examples
+///
+/// ### Video
+///
+/// #### Input stream
 ///
 /// ```rust
 /// use ffmpeg_sidecar::log_parser::try_parse_stream;
 /// let line = "[info]   Stream #0:0: Video: wrapped_avframe, rgb24, 320x240 [SAR 1:1 DAR 4:3], 25 fps, 25 tbr, 25 tbn\n";
 /// let stream = try_parse_stream(line).unwrap();
 /// assert!(stream.format == "wrapped_avframe");
-/// assert!(stream.pix_fmt == "rgb24");
-/// assert!(stream.width == 320);
-/// assert!(stream.height == 240);
-/// assert!(stream.fps == 25.0);
+/// assert!(stream.language == "");
 /// assert!(stream.parent_index == 0);
-/// ```
+/// assert!(stream.stream_index == 0);
+/// assert!(stream.is_video());
+/// let video_data = stream.video_data();
+/// assert!(video_data.pix_fmt == "rgb24");
+/// assert!(video_data.width == 320);
+/// assert!(video_data.height == 240);
+/// assert!(video_data.fps == 25.0);
+///  ```
 ///
-/// ### Output stream:
+///  #### Output stream
+///
+///  ```rust
+///  use ffmpeg_sidecar::log_parser::try_parse_stream;
+///  let line = "[info]   Stream #1:5(eng): Video: h264 (avc1 / 0x31637661), yuv444p(tv, progressive), 320x240 [SAR 1:1 DAR 4:3], q=2-31, 25 fps, 12800 tbn\n";
+///  let stream = try_parse_stream(line).unwrap();
+///  assert!(stream.format == "h264");
+///  assert!(stream.language == "eng");
+///  assert!(stream.parent_index == 1);
+///  assert!(stream.stream_index == 5);
+///  assert!(stream.is_video());
+///  let video_data = stream.video_data();
+///  assert!(video_data.pix_fmt == "yuv444p");
+///  assert!(video_data.width == 320);
+///  assert!(video_data.height == 240);
+///  assert!(video_data.fps == 25.0);
+///  ```
+///
+/// ### Audio
+///
+/// #### Input Stream
 ///
 /// ```rust
 /// use ffmpeg_sidecar::log_parser::try_parse_stream;
-/// let line = "[info]   Stream #1:0: Video: h264 (avc1 / 0x31637661), yuv444p(tv, progressive), 320x240 [SAR 1:1 DAR 4:3], q=2-31, 25 fps, 12800 tbn\n";
+/// let line = "[info]   Stream #0:1(eng): Audio: opus, 48000 Hz, stereo, fltp (default)\n";
 /// let stream = try_parse_stream(line).unwrap();
-/// assert!(stream.format == "h264");
-/// assert!(stream.pix_fmt == "yuv444p");
-/// assert!(stream.width == 320);
-/// assert!(stream.height == 240);
-/// assert!(stream.fps == 25.0);
-/// assert!(stream.parent_index == 1);
+/// assert!(stream.format == "opus");
+/// assert!(stream.language == "eng");
+/// assert!(stream.parent_index == 0);
+/// assert!(stream.stream_index == 1);
+/// assert!(stream.is_audio());
+/// let audio_data = stream.audio_data();
+/// assert!(audio_data.sample_rate == 48000);
+/// assert!(audio_data.channels == "stereo");
 /// ```
-///
-/// ### Audio output stream:
 ///
 /// ```rust
 /// use ffmpeg_sidecar::log_parser::try_parse_stream;
-/// let line = "[info]   Stream #0:1: Audio: mp2, 44100 Hz, mono, s16, 384 kb/s\n";
+/// let line = "[info]   Stream #3:10(ger): Audio: dts (DTS-HD MA), 48000 Hz, 7.1, s32p (24 bit)\n";
 /// let stream = try_parse_stream(line).unwrap();
-/// assert!(stream.stream_type == "Audio");
+/// assert!(stream.format == "dts");
+/// assert!(stream.language == "ger");
+/// assert!(stream.parent_index == 3);
+/// assert!(stream.stream_index == 10);
+/// assert!(stream.is_audio());
+/// let audio_data = stream.audio_data();
+/// assert!(audio_data.sample_rate == 48000);
+/// assert!(audio_data.channels == "7.1");
 /// ```
 ///
-pub fn try_parse_stream(mut string: &str) -> Option<AVStream> {
+/// ### Output stream
+///
+/// ```rust
+/// use ffmpeg_sidecar::log_parser::try_parse_stream;
+/// let line = "[info]   Stream #10:1: Audio: mp2, 44100 Hz, mono, s16, 384 kb/s\n";
+/// let stream = try_parse_stream(line).unwrap();
+/// assert!(stream.format == "mp2");
+/// assert!(stream.language == "");
+/// assert!(stream.parent_index == 10);
+/// assert!(stream.stream_index == 1);
+/// assert!(stream.is_audio());
+/// let audio_data = stream.audio_data();
+/// assert!(audio_data.sample_rate == 44100);
+/// assert!(audio_data.channels == "mono");
+/// ```
+///
+/// ### Subtitle
+///
+/// #### Input Stream
+///
+/// ```rust
+/// use ffmpeg_sidecar::log_parser::try_parse_stream;
+/// let line = "[info]   Stream #0:4(eng): Subtitle: ass (default) (forced)\n";
+/// let stream = try_parse_stream(line).unwrap();
+/// assert!(stream.format == "ass");
+/// assert!(stream.language == "eng");
+/// assert!(stream.parent_index == 0);
+/// assert!(stream.stream_index == 4);
+/// assert!(stream.is_subtitle());
+/// ```
+///
+/// ```rust
+/// use ffmpeg_sidecar::log_parser::try_parse_stream;
+/// let line = "[info]   Stream #0:13(dut): Subtitle: hdmv_pgs_subtitle, 1920x1080\n";
+/// let stream = try_parse_stream(line).unwrap();
+/// assert!(stream.format == "hdmv_pgs_subtitle");
+/// assert!(stream.language == "dut");
+/// assert!(stream.parent_index == 0);
+/// assert!(stream.stream_index == 13);
+/// assert!(stream.is_subtitle());
+/// ```
+/// ### Other
+///
+/// #### Input Stream
+///
+/// ```rust
+/// use ffmpeg_sidecar::log_parser::try_parse_stream;
+/// let line = "[info]   Stream #0:2(und): Data: none (rtp  / 0x20707472), 53 kb/s (default)\n";
+/// let stream = try_parse_stream(line).unwrap();
+/// assert!(stream.format == "none");
+/// assert!(stream.language == "und");
+/// assert!(stream.parent_index == 0);
+/// assert!(stream.stream_index == 2);
+/// assert!(stream.is_other());
+/// ```
+///
+/// ```rust
+/// use ffmpeg_sidecar::log_parser::try_parse_stream;
+/// let line = "[info]   Stream #0:2[0x3](eng): Data: bin_data (text / 0x74786574)\n";
+/// let stream = try_parse_stream(line).unwrap();
+/// assert!(stream.format == "bin_data");
+/// assert!(stream.language == "eng");
+/// assert!(stream.parent_index == 0);
+/// assert!(stream.stream_index == 2);
+/// assert!(stream.is_other());
+/// ```
+pub fn try_parse_stream(string: &str) -> Option<Stream> {
   let raw_log_message = string.to_string();
 
-  string = string
+  let string = string
     .strip_prefix("[info]")
     .unwrap_or(string)
     .trim()
     .strip_prefix("Stream #")?;
+  let mut comma_iter = CommaIter::new(&string);
+  let mut colon_iter = comma_iter.next()?.split(':');
 
-  let mut colon_parts = string.split(':');
-  let parent_index = colon_parts.next()?.parse::<usize>().ok()?;
-  let stream_type = colon_parts.nth(1)?.trim().to_string();
-  if stream_type != "Video" {
-    // Audio is not well-supported yet (PRs welcome)
-    return Some(AVStream {
-      stream_type,
-      format: "unknown".into(),
-      pix_fmt: "unknown".into(),
-      width: 0,
-      height: 0,
-      fps: 0.0,
-      parent_index,
-      raw_log_message,
-    });
-  }
-  let comma_string = colon_parts.next()?.trim();
-  let mut comma_iter = CommaIter::new(comma_string);
+  let parent_index = colon_iter.next()?.parse::<usize>().ok()?;
 
-  let format = comma_iter
+  // Here handle pattern such as `2[0x3](eng)`
+  let indices_and_maybe_language = colon_iter
+    .next()?
+    // Remove everything inside and including square brackets
+    .split(|c| c == '[' || c == ']')
+    .step_by(2)
+    .collect::<String>();
+  let mut parenthesis_iter = indices_and_maybe_language.split('(');
+  let stream_index = parenthesis_iter.next()?.trim().parse::<usize>().ok()?;
+  let language = parenthesis_iter.next().map_or("".to_string(), |lang| {
+    lang.trim_end_matches(')').to_string()
+  });
+
+  // Here handle pattern such as `Video: av1 (Main)`
+  let stream_type = colon_iter.next()?.trim();
+  let format = colon_iter
     .next()?
     .trim()
-    .split(&[' ', '(']) // trim trailing junk like " (avc1 / 0x31637661)"
+    .split(&[' ', '(']) // trim trailing junk like `(Main)`
     .next()?
     .to_string();
 
+  // For audio and video handle remaining string in specialized functions.
+  let type_specific_data: TypeSpecificData = match stream_type {
+    "Audio" => try_parse_audio_stream(comma_iter)?,
+    "Subtitle" => TypeSpecificData::Subtitle(),
+    "Video" => try_parse_video_stream(comma_iter)?,
+    _ => TypeSpecificData::Other(),
+  };
+
+  Some(Stream {
+    format,
+    language,
+    parent_index,
+    stream_index,
+    raw_log_message,
+    type_specific_data,
+  })
+}
+
+/// Parses the log output part that is specific to audio streams.
+fn try_parse_audio_stream(mut comma_iter: CommaIter) -> Option<TypeSpecificData> {
+  let sample_rate = comma_iter
+    .next()?
+    .trim()
+    .split_whitespace()
+    .next()?
+    .parse::<usize>()
+    .ok()?;
+
+  let channels = comma_iter.next()?.trim().to_string();
+
+  Some(TypeSpecificData::Audio(AudioStream {
+    sample_rate,
+    channels,
+  }))
+}
+
+/// Parses the log output part that is specific to video streams.
+fn try_parse_video_stream(mut comma_iter: CommaIter) -> Option<TypeSpecificData> {
   let pix_fmt = comma_iter
     .next()?
     .trim()
@@ -352,24 +491,24 @@ pub fn try_parse_stream(mut string: &str) -> Option<AVStream> {
   let width = dims_iter.next()?.parse::<u32>().ok()?;
   let height = dims_iter.next()?.parse::<u32>().ok()?;
 
-  let fps = string
-    .split("fps,")
-    .next()?
-    .split_whitespace()
-    .last()?
-    .parse()
-    .ok()?;
+  // FPS does not have to be the next part, so we iterate until we find it. There is nothing else we
+  // are interested in at this point, so its OK to skip anything in-between.
+  let fps = comma_iter
+    .find_map(|part| {
+      if part.trim().ends_with("fps") {
+        part.trim().split_whitespace().next()
+      } else {
+        None
+      }
+    })
+    .and_then(|fps_str| fps_str.parse::<f32>().ok())?;
 
-  Some(AVStream {
-    stream_type,
-    parent_index,
-    format,
+  Some(TypeSpecificData::Video(VideoStream {
     pix_fmt,
     width,
     height,
     fps,
-    raw_log_message,
-  })
+  }))
 }
 
 /// Parse a progress update line from ffmpeg.

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -7,7 +7,7 @@ use crate::{
   comma_iter::CommaIter,
   event::{
     AudioStream, FfmpegConfiguration, FfmpegDuration, FfmpegEvent, FfmpegInput, FfmpegOutput,
-    FfmpegProgress, FfmpegVersion, LogLevel, Stream, TypeSpecificData, VideoStream,
+    FfmpegProgress, FfmpegVersion, LogLevel, Stream, StreamTypeSpecificData, VideoStream,
   },
   read_until_any::read_until_any,
 };
@@ -442,11 +442,11 @@ pub fn try_parse_stream(string: &str) -> Option<Stream> {
     .to_string();
 
   // For audio and video handle remaining string in specialized functions.
-  let type_specific_data: TypeSpecificData = match stream_type {
+  let type_specific_data: StreamTypeSpecificData = match stream_type {
     "Audio" => try_parse_audio_stream(comma_iter)?,
-    "Subtitle" => TypeSpecificData::Subtitle(),
+    "Subtitle" => StreamTypeSpecificData::Subtitle(),
     "Video" => try_parse_video_stream(comma_iter)?,
-    _ => TypeSpecificData::Other(),
+    _ => StreamTypeSpecificData::Other(),
   };
 
   Some(Stream {
@@ -460,7 +460,7 @@ pub fn try_parse_stream(string: &str) -> Option<Stream> {
 }
 
 /// Parses the log output part that is specific to audio streams.
-fn try_parse_audio_stream(mut comma_iter: CommaIter) -> Option<TypeSpecificData> {
+fn try_parse_audio_stream(mut comma_iter: CommaIter) -> Option<StreamTypeSpecificData> {
   let sample_rate = comma_iter
     .next()?
     .trim()
@@ -471,14 +471,14 @@ fn try_parse_audio_stream(mut comma_iter: CommaIter) -> Option<TypeSpecificData>
 
   let channels = comma_iter.next()?.trim().to_string();
 
-  Some(TypeSpecificData::Audio(AudioStream {
+  Some(StreamTypeSpecificData::Audio(AudioStream {
     sample_rate,
     channels,
   }))
 }
 
 /// Parses the log output part that is specific to video streams.
-fn try_parse_video_stream(mut comma_iter: CommaIter) -> Option<TypeSpecificData> {
+fn try_parse_video_stream(mut comma_iter: CommaIter) -> Option<StreamTypeSpecificData> {
   let pix_fmt = comma_iter
     .next()?
     .trim()
@@ -503,7 +503,7 @@ fn try_parse_video_stream(mut comma_iter: CommaIter) -> Option<TypeSpecificData>
     })
     .and_then(|fps_str| fps_str.parse::<f32>().ok())?;
 
-  Some(TypeSpecificData::Video(VideoStream {
+  Some(StreamTypeSpecificData::Video(VideoStream {
     pix_fmt,
     width,
     height,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,12 +1,12 @@
-use crate::event::{AVStream, FfmpegEvent, FfmpegInput, FfmpegOutput};
+use crate::event::{FfmpegEvent, FfmpegInput, FfmpegOutput, Stream};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FfmpegMetadata {
   expected_output_streams: usize,
   pub outputs: Vec<FfmpegOutput>,
-  pub output_streams: Vec<AVStream>,
+  pub output_streams: Vec<Stream>,
   pub inputs: Vec<FfmpegInput>,
-  pub input_streams: Vec<AVStream>,
+  pub input_streams: Vec<Stream>,
 
   /// Whether all metadata from the parent process has been gathered into this struct
   completed: bool,

--- a/src/pix_fmt.rs
+++ b/src/pix_fmt.rs
@@ -1,4 +1,4 @@
-use crate::event::AVStream;
+use crate::event::VideoStream;
 
 /// Map from the pix_fmt identifier string (e.g. `rgb24`) to the number of bits
 /// per pixel (e.g. `24`). Returns `None` if the pix_fmt is unsupported/unrecognized.
@@ -227,12 +227,12 @@ pub fn get_bits_per_pixel(pix_fmt: &str) -> Option<u32> {
   }
 }
 
-pub fn get_bytes_per_frame(stream: &AVStream) -> Option<u32> {
-  let bits_per_pixel = get_bits_per_pixel(&stream.pix_fmt)?;
+pub fn get_bytes_per_frame(video_data: &VideoStream) -> Option<u32> {
+  let bits_per_pixel = get_bits_per_pixel(&video_data.pix_fmt)?;
   // Enforce byte-alignment, since we don't currently have buffer reads in
   // sub-byte increments.
   match bits_per_pixel % 8 {
-    0 => Some(stream.width * stream.height * bits_per_pixel / 8),
+    0 => Some(video_data.width * video_data.height * bits_per_pixel / 8),
     _ => None,
   }
 }


### PR DESCRIPTION
* Refactor code into common processing for all streams and spezialized functions for audio and video.
* Update code examples
* Change line breaks in lib.rs to LF
* Add handling of streams that contain additional identifiers in square
  brackets such as `Stream #0:1[0x2](eng):`. These are found in mov
  containers.

Partly discussed in https://github.com/nathanbabcock/ffmpeg-sidecar/issues/49