### PR TITLE
Fix non-default feature build: Feature gate `unpack_ffmpeg` with `download_ffmpeg`

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: FedericoCarboni/setup-ffmpeg@v3
       - name: Build
         run: cargo build --verbose
+      - name: Check without default features
+        run: cargo check --no-default-features
       - name: Run tests
         run: cargo test --all-targets --all-features --verbose
       - name: Try auto-download

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: FedericoCarboni/setup-ffmpeg@v3
       - name: Build
         run: cargo build --verbose
+      - name: Check without default features
+        run: cargo check --no-default-features
       - name: Run tests
         run: cargo test --all-targets --all-features --verbose
       - name: Try auto-download

--- a/src/download.rs
+++ b/src/download.rs
@@ -171,6 +171,7 @@ pub fn download_ffmpeg_package(url: &str, download_dir: &Path) -> anyhow::Result
 
 /// After downloading, unpacks the archive to a folder, moves the binaries to
 /// their final location, and deletes the archive and temporary folder.
+#[cfg(feature = "download_ffmpeg")]
 pub fn unpack_ffmpeg(from_archive: &PathBuf, binary_folder: &Path) -> anyhow::Result<()> {
   let temp_dirname = UNPACK_DIRNAME;
   let temp_folder = binary_folder.join(temp_dirname);


### PR DESCRIPTION
Currently compilation fails when building for non-linux without the `download_ffmpeg` feature.

This happens because the `zip` library is (correctly) feature gated to `download_ffmpeg`. This in turn is used by `unpack_ffmpeg` which wasn't behind the feature flag!