### PR TITLE
Add `rust-toolchain` and set MSRV to 1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ffmpeg-sidecar"
 version = "2.0.0"
 edition = "2021"
+rust-version = "1.79"
 description = "Wrap a standalone FFmpeg binary in an intuitive Iterator interface."
 authors = ["Nathan Babcock <nathan.r.babcock@gmail.com>"]
 categories = ["multimedia"]
@@ -39,4 +40,4 @@ nix = { version = "0.29.0", optional = true, features = [
 
 [dependencies]
 anyhow = "1.0.79"
-reqwest = { version = "0.12.8", optional = true, features = ["blocking"]}
+reqwest = { version = "0.12.8", optional = true, features = ["blocking"] }

--- a/examples/named_pipes.rs
+++ b/examples/named_pipes.rs
@@ -19,9 +19,9 @@ fn main() -> anyhow::Result<()> {
   use std::sync::mpsc;
   use std::thread;
 
-  const VIDEO_PIPE_NAME: &'static str = pipe_name!("ffmpeg_video");
-  const AUDIO_PIPE_NAME: &'static str = pipe_name!("ffmpeg_audio");
-  const SUBTITLES_PIPE_NAME: &'static str = pipe_name!("ffmpeg_subtitles");
+  const VIDEO_PIPE_NAME: &str = pipe_name!("ffmpeg_video");
+  const AUDIO_PIPE_NAME: &str = pipe_name!("ffmpeg_audio");
+  const SUBTITLES_PIPE_NAME: &str = pipe_name!("ffmpeg_subtitles");
 
   // Prepare an FFmpeg command with separate outputs for video, audio, and subtitles.
   let mut command = FfmpegCommand::new();
@@ -31,7 +31,7 @@ fn main() -> anyhow::Result<()> {
     .overwrite() // <- overwrite required on windows
     // Generate test video
     .format("lavfi")
-    .input(format!("testsrc=size=1920x1080:rate=60:duration=10"))
+    .input("testsrc=size=1920x1080:rate=60:duration=10")
     // Generate test audio
     .format("lavfi")
     .input("sine=frequency=1000:duration=10")
@@ -127,7 +127,7 @@ fn main() -> anyhow::Result<()> {
         Ok(())
       });
 
-      return Ok((thread, ready_sender));
+      Ok((thread, ready_sender))
     })
     .collect::<Result<Vec<_>>>()?;
 

--- a/examples/sockets.rs
+++ b/examples/sockets.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
     .overwrite() // <- overwrite required on windows
     // Generate test video
     .format("lavfi")
-    .input(format!("testsrc=size=1920x1080:rate=60:duration=10"))
+    .input("testsrc=size=1920x1080:rate=60:duration=10")
     // Generate test audio
     .format("lavfi")
     .input("sine=frequency=1000:duration=10")
@@ -76,7 +76,7 @@ fn listen_for_connections(tcp_port: u32, exit_receiver: Receiver<()>) -> Result<
 
   let mut handler_threads = Vec::new();
   loop {
-    if let Ok(_) = exit_receiver.try_recv() {
+    if exit_receiver.try_recv().is_ok() {
       break;
     }
     match listener.accept() {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,9 @@
+# If you see this, run "rustup self update" to get rustup 1.23 or newer.
+
+# NOTE: above comment is for older `rustup` (before TOML support was added),
+# which will treat the first line as the toolchain name, and therefore show it
+# to the user in the error, instead of "error: invalid channel name '[toolchain]'".
+
+[toolchain]
+channel = "1.79"  # Avoid specifying a patch version here; see https://github.com/emilk/eframe_template/issues/145
+components = ["rustfmt", "clippy"]

--- a/src/command.rs
+++ b/src/command.rs
@@ -658,7 +658,7 @@ impl FfmpegCommand {
       .get_args()
       .filter_map(|s| {
         s.to_str().map(|s| {
-          if s.starts_with("-") {
+          if s.starts_with('-') {
             format!("\\\n  {s}")
           } else {
             s.to_owned()


### PR DESCRIPTION
Having a set MSRV is a good idea, as is enforcing it with a `rust-toolchain` file.

We can probably use an earlier version if you prefer; i just went with 1.79 for no particular reason. Let me know!