### PR TITLE
v2.0 docs & cleanup

### DIFF
--- a/.github/workflows/mac-m1.yml
+++ b/.github/workflows/mac-m1.yml
@@ -21,5 +21,7 @@ jobs:
         run: cargo run --example download_ffmpeg -- ../deps
       - name: Build
         run: cargo build --verbose
+      - name: Check without default features
+        run: cargo check --no-default-features
       - name: Run tests
         run: cargo test --all-targets --all-features --verbose -- --skip lib.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,17 @@ repository = "https://github.com/nathanbabcock/ffmpeg-sidecar"
 readme = "README.md"
 license = "MIT"
 
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+anyhow = "1.0.79"
+ureq = { version = "2.10.1", optional = true }
+
 [features]
 default = ["download_ffmpeg"]
 download_ffmpeg = ["dep:ureq", "dep:tar", "dep:xz2", "dep:zip"]
 named_pipes = ["dep:winapi", "dep:nix"]
-
-[lib]
-crate-type = ["lib"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tar = { version = "0.4.42", optional = true }
@@ -38,6 +42,6 @@ nix = { version = "0.29.0", optional = true, features = [
   "fs"
 ] }
 
-[dependencies]
-anyhow = "1.0.79"
-ureq = { version = "2.10.1", optional = true }
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/examples/download_ffmpeg.rs
+++ b/examples/download_ffmpeg.rs
@@ -1,15 +1,13 @@
-use ffmpeg_sidecar::{
-  command::ffmpeg_is_installed,
-  download::{check_latest_version, download_ffmpeg_package, ffmpeg_download_url, unpack_ffmpeg},
-  paths::sidecar_dir,
-  version::ffmpeg_version_with_path,
-};
-use std::{
-  env::current_exe,
-  path::{Component, PathBuf},
-};
-
+#[cfg(feature = "download_ffmpeg")]
 fn main() -> anyhow::Result<()> {
+  use ffmpeg_sidecar::{
+    command::ffmpeg_is_installed,
+    download::{check_latest_version, download_ffmpeg_package, ffmpeg_download_url, unpack_ffmpeg},
+    paths::sidecar_dir,
+    version::ffmpeg_version_with_path,
+  };
+  use std::env::current_exe;
+
   if ffmpeg_is_installed() {
     println!("FFmpeg is already installed! 🎉");
     println!("For demo purposes, we'll re-download and unpack it anyway.");
@@ -56,7 +54,10 @@ fn main() -> anyhow::Result<()> {
   Ok(())
 }
 
-fn resolve_relative_path(path_buf: PathBuf) -> PathBuf {
+#[cfg(feature = "download_ffmpeg")]
+fn resolve_relative_path(path_buf: std::path::PathBuf) -> std::path::PathBuf {
+  use std::path::{Component, PathBuf};
+
   let mut components: Vec<PathBuf> = vec![];
   for component in path_buf.as_path().components() {
     match component {
@@ -71,4 +72,11 @@ fn resolve_relative_path(path_buf: PathBuf) -> PathBuf {
     }
   }
   PathBuf::from_iter(components)
+}
+
+#[cfg(not(feature = "download_ffmpeg"))]
+fn main() {
+  eprintln!(r#"This example requires the "download_ffmpeg" feature to be enabled."#);
+  println!("The feature is included by default unless manually disabled.");
+  println!("Please run `cargo run --example download_ffmpeg`.");
 }

--- a/examples/ffprobe.rs
+++ b/examples/ffprobe.rs
@@ -1,6 +1,7 @@
-use ffmpeg_sidecar::{download::auto_download, ffprobe::ffprobe_version};
-
+#[cfg(feature = "download_ffmpeg")]
 fn main() {
+  use ffmpeg_sidecar::{download::auto_download, ffprobe::ffprobe_version};
+
   // Download ffprobe from a configured source.
   // Note that not all distributions include ffprobe in their bundle.
   auto_download().unwrap();
@@ -8,4 +9,11 @@ fn main() {
   // Try running the executable and printing the version number.
   let version = ffprobe_version().unwrap();
   println!("ffprobe version: {}", version);
+}
+
+#[cfg(not(feature = "download_ffmpeg"))]
+fn main() {
+  eprintln!(r#"This example requires the "download_ffmpeg" feature to be enabled."#);
+  println!("The feature is included by default unless manually disabled.");
+  println!("Please run `cargo run --example download_ffmpeg`.");
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,4 +1,4 @@
-use ffmpeg_sidecar::{command::FfmpegCommand, event::FfmpegEvent};
+use ffmpeg_sidecar::command::FfmpegCommand;
 
 /// Iterates over the frames of a `testsrc`.
 ///
@@ -6,37 +6,18 @@ use ffmpeg_sidecar::{command::FfmpegCommand, event::FfmpegEvent};
 /// cargo run --example hello_world
 /// ```
 fn main() -> anyhow::Result<()> {
-  FfmpegCommand::new() // <- Builder API like `std::process::Command`
-    .testsrc() // <- Discoverable aliases for FFmpeg args
+  // Run an FFmpeg command that generates a test video
+  let iter = FfmpegCommand::new() // <- Builder API like `std::process::Command`
+    .testsrc()  // <- Discoverable aliases for FFmpeg args
     .rawvideo() // <- Convenient argument presets
-    .spawn()? // <- Uses an ordinary `std::process::Child`
-    .iter()? // <- Iterator over all log messages and video output
-    .for_each(|event: FfmpegEvent| {
-      match event {
-        FfmpegEvent::OutputFrame(frame) => {
-          println!("frame: {}x{}", frame.width, frame.height);
-          let _pixels: Vec<u8> = frame.data; // <- raw RGB pixels! 🎨
-        }
-        FfmpegEvent::Progress(progress) => {
-          eprintln!("Current speed: {}x", progress.speed); // <- parsed progress updates
-        }
-        FfmpegEvent::Log(_level, msg) => {
-          eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
-        }
-        FfmpegEvent::ParsedInputStream(stream) => {
-          if let Some(video_data) = stream.video_data() {
-            println!(
-              "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
-              stream.stream_index,
-              stream.parent_index,
-              video_data.fps,
-              video_data.width,
-              video_data.height
-            );
-          }
-        }
-        _ => {}
-      }
-    });
+    .spawn()?   // <- Ordinary `std::process::Child`
+    .iter()?;   // <- Blocking iterator over logs and output
+
+  // Use a regular "for" loop to read decoded video data
+  for frame in iter.filter_frames() {
+    println!("frame: {}x{}", frame.width, frame.height);
+    let _pixels: Vec<u8> = frame.data; // <- raw RGB pixels! 🎨
+  }
+
   Ok(())
 }

--- a/scripts/cargo-doc.sh
+++ b/scripts/cargo-doc.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Source: <https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577>
+
+# First, install nightly toolchain if needed:
+# rustup install nightly
+
+RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -1,4 +1,5 @@
+#!/bin/bash
+
 # Backtrace is on by default, and does not respect Cargo.toml
 # [env] section, even with force = true.
-export RUST_BACKTRACE=0
-cargo test
+RUST_BACKTRACE=0 cargo test

--- a/scripts/ffmpeg.sh
+++ b/scripts/ffmpeg.sh
@@ -1,22 +1,28 @@
-exit 1 # snippets only, not meant to be run together
+#!/bin/bash
 
-# testsrc
-ffmpeg \
-  -v level+info \
-  -f lavfi \
-  -i testsrc \
-  -y output/test.mp4
+# Each function body is intended to be copy-pasted directly into a terminal.
 
-# to /dev/null
-ffmpeg \
-  -v level+info \
-  -f lavfi \
-  -i testsrc \
-  -f rawvideo \
-  -pix_fmt rgb24 \
-  pipe > /dev/null
+testsrc() {
+  ffmpeg \
+    -v level+info \
+    -f lavfi \
+    -i testsrc \
+    -y output/test.mp4
+}
+
+toDevNull() {
+  ffmpeg \
+    -v level+info \
+    -f lavfi \
+    -i testsrc \
+    -f rawvideo \
+    -pix_fmt rgb24 \
+    pipe > /dev/null
+}
+
 # to stdout: 'pipe', 'pipe:', 'pipe:1', '-'
 # to stderr: 'pipe:2'
 
-# pix_fmts
-ffmpeg -hide_banner -pix_fmts
+pix_fmts() {
+  ffmpeg -hide_banner -pix_fmts
+}

--- a/src/child.rs
+++ b/src/child.rs
@@ -1,3 +1,5 @@
+//! Wrapper around `std::process::Child` containing a spawned FFmpeg command.
+
 use std::{
   io::{self, Write},
   process::{Child, ChildStderr, ChildStdin, ChildStdout, ExitStatus},
@@ -68,11 +70,7 @@ impl FfmpegChild {
   /// s      Show QP histogram
   /// ```
   pub fn send_stdin_command(&mut self, command: &[u8]) -> anyhow::Result<()> {
-    let mut stdin = self
-      .inner
-      .stdin
-      .take()
-      .context("Missing child stdin")?;
+    let mut stdin = self.inner.stdin.take().context("Missing child stdin")?;
     stdin.write_all(command)?;
     self.inner.stdin.replace(stdin);
     Ok(())

--- a/src/comma_iter.rs
+++ b/src/comma_iter.rs
@@ -1,3 +1,5 @@
+//! An internal utility used to parse comma-separated values in FFmpeg logs.
+
 use std::str::Chars;
 
 /// An iterator over comma-separated values, **ignoring commas inside parentheses**.

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,5 @@
+//! Builder interface for FFmpeg commands.
+
 use crate::{child::FfmpegChild, paths::ffmpeg_path};
 use std::{
   ffi::OsStr,

--- a/src/download.rs
+++ b/src/download.rs
@@ -67,7 +67,7 @@ pub fn auto_download() -> Result<()> {
 
 /// Parse the the MacOS version number from a JSON string manifest file.
 ///
-/// Example input: https://evermeet.cx/ffmpeg/info/ffmpeg/release
+/// Example input: <https://evermeet.cx/ffmpeg/info/ffmpeg/release>
 ///
 /// ```rust
 /// use ffmpeg_sidecar::download::parse_macos_version;
@@ -87,7 +87,7 @@ pub fn parse_macos_version(version: &str) -> Option<String> {
 
 /// Parse the the Linux version number from a long manifest text file.
 ///
-/// Example input: https://johnvansickle.com/ffmpeg/release-readme.txt
+/// Example input: <https://johnvansickle.com/ffmpeg/release-readme.txt>
 ///
 /// ```rust
 /// use ffmpeg_sidecar::download::parse_linux_version;

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,8 +1,11 @@
+//! Utilities for downloading and unpacking FFmpeg binaries.
+
 use anyhow::Result;
 
 #[cfg(feature = "download_ffmpeg")]
 use std::path::{Path, PathBuf};
 
+/// The default directory name for unpacking a downloaded FFmpeg release archive.
 pub const UNPACK_DIRNAME: &str = "ffmpeg_release_temp";
 
 /// URL of a manifest file containing the latest published build of FFmpeg. The

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,3 +1,7 @@
+//! Any event that occurs during the execution of an FFmpeg command.
+
+/// Any event that occurs during the execution of an FFmpeg command,
+/// including log messages, parsed metadata, progress updates, and output.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FfmpegEvent {
   ParsedVersion(FfmpegVersion),
@@ -22,6 +26,7 @@ pub enum FfmpegEvent {
   Done,
 }
 
+/// The internal log level designated by FFmpeg on each message.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LogLevel {
   Info,

--- a/src/ffprobe.rs
+++ b/src/ffprobe.rs
@@ -1,3 +1,5 @@
+//! Utilities related to the FFprobe binary.
+
 use crate::command::BackgroundCommand;
 use anyhow::Context;
 use std::{env::current_exe, ffi::OsStr, path::PathBuf};

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,3 +1,5 @@
+//! A stream of events from an FFmpeg process.
+
 use std::{
   io::{BufReader, ErrorKind, Read},
   process::{ChildStderr, ChildStdout},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 //! Wrap a standalone FFmpeg binary in an intuitive Iterator interface.
 //!
 //! ## Example
@@ -61,4 +63,5 @@ pub mod read_until_any;
 pub mod version;
 
 #[cfg(feature = "named_pipes")]
+#[cfg_attr(docsrs, doc(cfg(feature = "named_pipes")))]
 pub mod named_pipes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,45 +5,24 @@
 //! ## Example
 //!
 //! ```rust
-//! use ffmpeg_sidecar::{command::FfmpegCommand, event::FfmpegEvent};
+//! use ffmpeg_sidecar::command::FfmpegCommand;
+//! fn main() -> anyhow::Result<()> {
+//!   // Run an FFmpeg command that generates a test video
+//!   let iter = FfmpegCommand::new() // <- Builder API like `std::process::Command`
+//!     .testsrc()  // <- Discoverable aliases for FFmpeg args
+//!     .rawvideo() // <- Convenient argument presets
+//!     .spawn()?   // <- Ordinary `std::process::Child`
+//!     .iter()?;   // <- Blocking iterator over logs and output
 //!
-//!fn main() -> anyhow::Result<()> {
-//!  FfmpegCommand::new() // <- Builder API like `std::process::Command`
-//!      .testsrc() // <- Discoverable aliases for FFmpeg args
-//!      .rawvideo() // <- Convenient argument presets
-//!      .spawn()? // <- Uses an ordinary `std::process::Child`
-//!      .iter()? // <- Iterator over all log messages and video output
-//!      .for_each(|event: FfmpegEvent| {
-//!        match event {
-//!          FfmpegEvent::OutputFrame(frame) => {
-//!            println!("frame: {}x{}", frame.width, frame.height);
-//!            let _pixels: Vec<u8> = frame.data; // <- raw RGB pixels! 🎨
-//!          }
-//!          FfmpegEvent::Progress(progress) => {
-//!            eprintln!("Current speed: {}x", progress.speed); // <- parsed progress updates
-//!          }
-//!          FfmpegEvent::Log(_level, msg) => {
-//!            eprintln!("[ffmpeg] {}", msg); // <- granular log message from stderr
-//!          }
-//!          FfmpegEvent::ParsedInputStream(stream) => {
-//!            if let Some(video_data) = stream.video_data() {
-//!              println!(
-//!                "Found video stream with index {} in input {} that has fps {}, width {}px, height {}px.",
-//!                stream.stream_index,
-//!                stream.parent_index,
-//!                video_data.fps,
-//!                video_data.width,
-//!                video_data.height
-//!              );
-//!            }
-//!          }
-//!          _ => {}
-//!        }
-//!      });
-//!  Ok(())
-//!}
+//!   // Use a regular "for" loop to read decoded video data
+//!   for frame in iter.filter_frames() {
+//!     println!("frame: {}x{}", frame.width, frame.height);
+//!     let _pixels: Vec<u8> = frame.data; // <- raw RGB pixels! 🎨
+//!   }
+//!
+//!   Ok(())
+//! }
 //! ```
-//!
 
 #[cfg(test)]
 mod test;

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -1,3 +1,5 @@
+//! Internal methods for parsing FFmpeg CLI log output.
+
 use std::{
   io::{BufReader, Read},
   str::from_utf8,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,3 +1,5 @@
+//! Information about an FFmpeg process and its streams.
+
 use crate::event::{FfmpegEvent, FfmpegInput, FfmpegOutput, Stream};
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/named_pipes.rs
+++ b/src/named_pipes.rs
@@ -17,7 +17,7 @@ macro_rules! pipe_name {
 #[cfg(windows)]
 pub struct NamedPipeHandle(*mut winapi::ctypes::c_void);
 
-/// https://github.com/retep998/winapi-rs/issues/396
+/// <https://github.com/retep998/winapi-rs/issues/396>
 #[cfg(windows)]
 unsafe impl Send for NamedPipeHandle {}
 
@@ -35,7 +35,7 @@ pub struct NamedPipe {
 #[cfg(windows)]
 impl NamedPipe {
   /// On Windows the pipe name must be in the format `\\.\pipe\{pipe_name}`.
-  /// @see https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createnamedpipew
+  /// @see <https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createnamedpipew>
   pub fn new<S: AsRef<str>>(pipe_name: S) -> Result<Self> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;

--- a/src/named_pipes.rs
+++ b/src/named_pipes.rs
@@ -1,3 +1,9 @@
+//! Cross-platform abstraction over Windows async named pipes and Unix FIFO.
+//!
+//! The primary use-case is streaming multiple outputs from FFmpeg into a Rust program.
+//! For more commentary and end-to-end usage, see `examples/named_pipes.rs`:
+//! <https://github.com/nathanbabcock/ffmpeg-sidecar/blob/main/examples/named_pipes.rs>
+
 use anyhow::Result;
 use std::io::Read;
 
@@ -14,6 +20,7 @@ macro_rules! pipe_name {
   };
 }
 
+/// Windows-only; an FFI pointer to a named pipe handle.
 #[cfg(windows)]
 pub struct NamedPipeHandle(*mut winapi::ctypes::c_void);
 
@@ -23,11 +30,14 @@ unsafe impl Send for NamedPipeHandle {}
 
 /// Cross-platform abstraction over Windows async named pipes and Unix FIFO.
 pub struct NamedPipe {
+  /// The name that the pipe was opened with. It will start with `\\.\pipe\` on Windows.
   pub name: String,
 
+  /// Windows-only; an FFI pointer to a named pipe handle.
   #[cfg(windows)]
   pub handle: NamedPipeHandle,
 
+  /// Unix-only; a blocking file handle to the FIFO.
   #[cfg(unix)]
   pub file: std::fs::File,
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,9 +1,10 @@
+//! Utilities for locating FFmpeg binaries on the system.
+
+use anyhow::Context;
 use std::{
   env::current_exe,
   path::{Path, PathBuf},
 };
-
-use anyhow::Context;
 
 /// Returns the default path of the FFmpeg executable, to be used as the
 /// argument to `Command::new`. It should first attempt to locate an FFmpeg

--- a/src/pix_fmt.rs
+++ b/src/pix_fmt.rs
@@ -1,3 +1,5 @@
+//! A database of the pixel formats supported by FFmpeg and their size per pixel.
+
 use crate::event::VideoStream;
 
 /// Map from the pix_fmt identifier string (e.g. `rgb24`) to the number of bits
@@ -227,6 +229,7 @@ pub fn get_bits_per_pixel(pix_fmt: &str) -> Option<u32> {
   }
 }
 
+/// Computes `width * height * bits_per_pixel / 8`
 pub fn get_bytes_per_frame(video_data: &VideoStream) -> Option<u32> {
   let bits_per_pixel = get_bits_per_pixel(&video_data.pix_fmt)?;
   // Enforce byte-alignment, since we don't currently have buffer reads in

--- a/src/read_until_any.rs
+++ b/src/read_until_any.rs
@@ -1,3 +1,5 @@
+//! Internal utility; `BufRead::read_until` with multiple delimiters.
+
 use std::io::{BufRead, ErrorKind, Result};
 
 /// `BufRead::read_until` with multiple delimiters.

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,3 +1,5 @@
+//! Utilities for checking local FFmpeg version string.
+
 use anyhow::Context;
 
 use crate::command::BackgroundCommand;


### PR DESCRIPTION
- [x] ci: add `cargo check` step to Mac M1 runner
- [x] refactor: organize imports to compile with all feature combinations
- [x] docs: include optional features in `cargo doc` output
- [x] docs: add rustdoc to most modules and structs
- [x] docs: simplify hello world
