### PR TITLE
Fix crash when using formats with bits per pixel size not divisible by 8

### DIFF
--- a/src/pix_fmt.rs
+++ b/src/pix_fmt.rs
@@ -234,8 +234,11 @@ pub fn get_bytes_per_frame(video_data: &VideoStream) -> Option<u32> {
   let bits_per_pixel = get_bits_per_pixel(&video_data.pix_fmt)?;
   // Enforce byte-alignment, since we don't currently have buffer reads in
   // sub-byte increments.
-  match bits_per_pixel % 8 {
-    0 => Some(video_data.width * video_data.height * bits_per_pixel / 8),
+  // Use the full frame buffer size for this, since formats like `yuvj420p` typically restrict a frame's size
+  // such that the buffer size has full bytes.
+  let num_bits = video_data.width * video_data.height * bits_per_pixel;
+  match num_bits % 8 {
+    0 => Some(num_bits / 8),
     _ => None,
   }
 }


### PR DESCRIPTION
Two separate fixes actually:

* `get_bytes_per_frame` assumed that a bits per pixel size that is not divisible by 8 means that it can't retrieve the frame size because that will yield a frame buffer with a non full-byte size. This is not _entirely_ true since for instance YUV formats typically have size restrictions such that their raw frame buffers don't run into this problem. ➡️ The check got changed to the frame buffer's size
* don't panic when `get_bytes_per_frame` can't return a size and instead report the error and exit 

The former fixes using yuv formats for me, the later is a bit of a general requirement for me since I deal with arbitrary user data: not being able to handle data is sad, but crashing over it goes too far :)