### PR TITLE
fix: consume stderr on wait

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -1,13 +1,11 @@
 //! Wrapper around `std::process::Child` containing a spawned FFmpeg command.
 
+use crate::iter::FfmpegIterator;
+use anyhow::Context;
 use std::{
   io::{self, Write},
   process::{Child, ChildStderr, ChildStdin, ChildStdout, ExitStatus},
 };
-
-use anyhow::Context;
-
-use crate::iter::FfmpegIterator;
 
 /// A wrapper around [`std::process::Child`] containing a spawned FFmpeg command.
 /// Provides interfaces for reading parsed metadata, progress updates, warnings and errors, and
@@ -97,9 +95,11 @@ impl FfmpegChild {
   }
 
   /// Waits for the inner child process to finish execution.
+  /// Automatically drops the stderr pipe, as it is no longer needed.
   ///
   /// Identical to `wait` in [`std::process::Child`].
   pub fn wait(&mut self) -> io::Result<ExitStatus> {
+    drop(self.take_stderr().take());
     self.inner.wait()
   }
 

--- a/src/child.rs
+++ b/src/child.rs
@@ -99,7 +99,7 @@ impl FfmpegChild {
   ///
   /// Identical to `wait` in [`std::process::Child`].
   pub fn wait(&mut self) -> io::Result<ExitStatus> {
-    drop(self.take_stderr().take());
+    drop(self.take_stderr());
     self.inner.wait()
   }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -769,5 +769,5 @@ fn test_wait() -> anyhow::Result<()> {
     .codec_video("gif")
     .format("null")
     .output("-");
-  wait_with_timeout(&mut command, 1000)
+  wait_with_timeout(&mut command, 5000)
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -40,6 +40,35 @@ fn spawn_with_timeout(command: &mut FfmpegCommand, timeout: u64) -> anyhow::Resu
   }
 }
 
+/// Returns `Err` if the timeout thread finishes before the FFmpeg process
+/// Note: this variant leaves behind a hung FFmpeg child process + thread until
+/// the test suite exits.
+fn wait_with_timeout(command: &mut FfmpegCommand, timeout: u64) -> anyhow::Result<()> {
+  let (sender, receiver) = mpsc::channel();
+
+  // Thread 1: Waits for 1000ms and sends a message
+  let timeout_sender = sender.clone();
+  thread::spawn(move || {
+    thread::sleep(Duration::from_millis(timeout));
+    timeout_sender.send("timeout").ok();
+  });
+
+  // Thread 2: Wait for the child to exit in another thread
+  let mut ffmpeg_child = command.spawn()?;
+  thread::spawn(move || {
+    ffmpeg_child.wait().unwrap();
+    sender.send("ffmpeg").ok();
+  });
+
+  // Race the two threads
+  let finished_first = receiver.recv()?;
+  match finished_first {
+    "timeout" => anyhow::bail!("Timeout thread expired before FFmpeg"),
+    "ffmpeg" => Ok(()),
+    _ => anyhow::bail!("Unknown message received"),
+  }
+}
+
 #[test]
 fn test_installed() {
   assert!(ffmpeg_is_installed());
@@ -714,4 +743,31 @@ fn test_no_empty_events() -> anyhow::Result<()> {
   assert!(empty_events == 0);
 
   Ok(())
+}
+
+/// This command generates an warning on every frame, e.g.:
+///
+/// ```txt
+/// [Parsed_palettegen_4 @ 0x600001574bb0] [warning] The input frame is not in sRGB, colors may be off
+///```
+///
+/// When used in combination with `.wait()`, these error messages can completely
+/// fill the stderr buffer and cause a deadlock. The solution is to
+/// automatically drop the stderr channel when `.wait()` is called.
+///
+/// <https://github.com/nathanbabcock/ffmpeg-sidecar/issues/70>
+#[test]
+fn test_wait() -> anyhow::Result<()> {
+  let mut command = FfmpegCommand::new();
+  command
+    .args("-color_primaries 1".split(' '))
+    .args("-color_trc 1".split(' '))
+    .args("-colorspace 1".split(' '))
+    .format("lavfi")
+    .input("yuvtestsrc=size=64x64:rate=60:duration=60")
+    .args("-vf palettegen=max_colors=164".split(' '))
+    .codec_video("gif")
+    .format("null")
+    .output("-");
+  wait_with_timeout(&mut command, 1000)
 }


### PR DESCRIPTION
Fixes #70 

The stderr channel of the FFmpeg process is configured with `Stdio::piped()` by default, which is used to parse log messages for the iterator. However, this can cause problems when used with `FfmpegChild.wait()`. Log messages will continue to fill up that piped stdio channel without ever being consumed. If there aren't too many log messages, the command will finish successfully. There's enough room for several hundred log lines, which is why this bug never surfaced before. However, once the whole buffer is filled, then FFmpeg will hang while it waits for more room to insert log messages (which continues indefinitely).

The solution is to automatically ~~drop~~ consume the piped stderr channel when `wait()` is called.