### PR TITLE
add windows ci

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,26 @@
+name: Windows
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: FedericoCarboni/setup-ffmpeg@v3
+      - name: Build
+        run: cargo build --verbose
+      - name: Check without default features
+        run: cargo check --no-default-features
+      - name: Run tests
+        run: cargo test --all-targets --all-features --verbose
+      - name: Try auto-download
+        run: cargo run --example download_ffmpeg


### PR DESCRIPTION
this is the same logic I do with my async fork. The reason timeout is at 10 minutes is for some reason it is a lot slower compared to linux and m1 runners

partly addresses #60 