### PR TITLE
fix: address flaky ci

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -361,6 +361,7 @@ fn test_metadata_duration() {
   assert!(metadata.duration() == Some(5.0));
 }
 
+#[ignore = "flaky behavior across different platforms"]
 #[test]
 fn test_kill_before_iter() {
   let mut child = FfmpegCommand::new().testsrc().rawvideo().spawn().unwrap();


### PR DESCRIPTION
- disable `test_kill_before_iter`
  - The behavior differs slightly across different platforms, and it's an edge case rather than core functionality. Not worth the friction it's creating on unrelated PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Marked a test as ignored due to inconsistent behavior across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->