### PR TITLE
emit audio progress events

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -156,13 +156,13 @@ pub struct FfmpegConfiguration {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FfmpegProgress {
-  /// index of the current output frame
+  /// Index of the current output frame. Will be `0` for audio-only progress events.
   pub frame: u32,
 
-  /// frames per second
+  /// Frames per second. Will be `0` for audio-only progress events.
   pub fps: f32,
 
-  /// Quality factor (if applicable)
+  /// Quality factor (if applicable). Will be `0` for audio-only progress events.
   pub q: f32,
 
   /// Current total size of the output in kilobytes


### PR DESCRIPTION
TL;DR: audio events will have `0` for unsupported fields. Fixes #81 

---

This is a quick non-breaking fix, supporting parsing audio progress messages which have a slightly different format than video ones:

**Video progress:**

```
[info] frame= 1996 fps=1984 q=-1.0 Lsize=     372kB time=00:01:19.72 bitrate=  38.2kbits/s speed=79.2x
```

**Audio progress:**

```txt
[info] size=      66kB time=00:00:02.21 bitrate= 245.0kbits/s speed=1.07x
```

Specifically audio progress omits `frame`, `fps`, and `q` fields.

The most thorough and typesafe fix will be to add a dedicated `AudioProgress` event type with those fields omitted. That would be a breaking change in conjunction with adding `#[non_exhaustive]` to support future added event types.

cc @ashhhleyyy fyi