### PR TITLE
feat: support linux arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         os:
           - windows-latest
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - macos-13
           - macos-14 # Mac M1 (ARM64)
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -33,6 +33,8 @@ pub fn ffmpeg_download_url() -> Result<&'static str> {
     Ok("https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip")
   } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
     Ok("https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz")
+  } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+    Ok("https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz")
   } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
     Ok("https://evermeet.cx/ffmpeg/getrelease/zip")
   } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {


### PR DESCRIPTION
ARM64 Ubuntu has been available for testing in Github Actions since January: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

The binary is downloaded from the same source as x64 Linux binaries: https://johnvansickle.com/ffmpeg/

Closes #63 