### PR TITLE
Switch off of deprecated `macos-13` Github Actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
           - windows-latest
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-13
           - macos-14 # Mac M1 (ARM64)
+          - macos-15-intel # (x86_64)
 
     env:
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
- Replace `macos-13` runner with `macos-15-intel`

<img width="693" height="1090" alt="image" src="https://github.com/user-attachments/assets/98f8b12f-022a-4d00-b100-4651707e12e7" />
