### PR TITLE
`input` and `output` should accept `AsRef<OsStr>`

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -50,7 +50,7 @@ impl FfmpegCommand {
   /// Alias for `-i` argument, the input file path or URL.
   ///
   /// To take input from stdin, use the value `-` or `pipe:0`.
-  pub fn input<S: AsRef<str>>(&mut self, path_or_url: S) -> &mut Self {
+  pub fn input<S: AsRef<OsStr>>(&mut self, path_or_url: S) -> &mut Self {
     self.arg("-i");
     self.arg(path_or_url.as_ref());
     self

--- a/src/command.rs
+++ b/src/command.rs
@@ -64,7 +64,7 @@ impl FfmpegCommand {
   /// preceding it, it is equivalent to calling `.arg()` directly. However,
   /// using this command helps label the purpose of the argument, and makes the
   /// code more readable at a glance.
-  pub fn output<S: AsRef<str>>(&mut self, path_or_url: S) -> &mut Self {
+  pub fn output<S: AsRef<OsStr>>(&mut self, path_or_url: S) -> &mut Self {
     self.arg(path_or_url.as_ref());
     self
   }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,10 @@
-use std::{sync::mpsc, thread, time::Duration};
+use std::{
+  ffi::{OsStr, OsString},
+  path::{Path, PathBuf},
+  sync::mpsc,
+  thread,
+  time::Duration,
+};
 
 use crate::{
   command::{ffmpeg_is_installed, FfmpegCommand},
@@ -77,6 +83,22 @@ fn test_installed() {
 #[test]
 fn test_version() {
   assert!(ffmpeg_version().is_ok());
+}
+
+#[test]
+fn test_input() {
+  let _ = FfmpegCommand::new()
+    .input("wibble/wobble.mp4");
+  let _ = FfmpegCommand::new()
+    .input(&"wibble/wobble.mp4".to_string());
+  let _ = FfmpegCommand::new()
+    .input(Path::new("wibble/wobble.mp4"));
+  let _ = FfmpegCommand::new()
+    .input(&PathBuf::from("wibble/wobble.mp4"));
+  let _ = FfmpegCommand::new()
+    .input(OsStr::new("wibble/wobble.mp4"));
+  let _ = FfmpegCommand::new()
+    .input(&OsString::from("wibble/wobble.mp4"));
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -102,6 +102,22 @@ fn test_input() {
 }
 
 #[test]
+fn test_output() {
+  let _ = FfmpegCommand::new()
+    .output("wibble/wobble.mp4");
+  let _ = FfmpegCommand::new()
+    .output(&"wibble/wobble.mp4".to_string());
+  let _ = FfmpegCommand::new()
+    .output(Path::new("wibble/wobble.mp4"));
+  let _ = FfmpegCommand::new()
+    .output(&PathBuf::from("wibble/wobble.mp4"));
+  let _ = FfmpegCommand::new()
+    .output(OsStr::new("wibble/wobble.mp4"));
+  let _ = FfmpegCommand::new()
+    .output(&OsString::from("wibble/wobble.mp4"));
+}
+
+#[test]
 fn test_frame_count() {
   let fps = 1;
   let duration = 5;


### PR DESCRIPTION
...since that's the constraint of `.arg` itself. this allows for using `Path` and `PathBuf` as well. afaik this is constraint is strictly looser (perhaps aside from some non-std types).